### PR TITLE
QueryDSL 설정하기 #12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,9 @@
+buildscript {
+	ext {
+		queryDslVersion = "5.0.0"
+	}
+}
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.1.4'
@@ -47,6 +53,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 
+	// QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 	// dev tools
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
@@ -60,6 +72,24 @@ dependencies {
 	testImplementation 'com.h2database:h2'
 	implementation 'com.google.code.gson:gson'
 	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+}
+
+// querydsl 시작
+def generated = "$buildDir/generated/querydsl"
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile).configureEach {
+	options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+	main.java.srcDirs += [ generated ]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+	delete file(generated)
 }
 
 test {

--- a/src/main/java/io/oduck/api/global/config/QueryDslConfig.java
+++ b/src/main/java/io/oduck/api/global/config/QueryDslConfig.java
@@ -1,0 +1,17 @@
+package io.oduck.api.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+    @PersistenceContext
+    private EntityManager em;
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/io/oduck/api/global/security/auth/controller/AuthController.java
+++ b/src/main/java/io/oduck/api/global/security/auth/controller/AuthController.java
@@ -31,7 +31,7 @@ public class AuthController {
     ) {
 
         authService.login(localAuthDto);
-        return ResponseEntity.status(302).location(URI.create(BASE_URL + "/auth/callback")).build();
+        return ResponseEntity.created(null).build();
     }
 
     @GetMapping("/status")

--- a/src/main/java/io/oduck/api/global/security/auth/service/AuthService.java
+++ b/src/main/java/io/oduck/api/global/security/auth/service/AuthService.java
@@ -4,7 +4,6 @@ import io.oduck.api.domain.member.entity.LoginType;
 import io.oduck.api.domain.member.entity.MemberProfile;
 import io.oduck.api.domain.member.entity.Role;
 import io.oduck.api.domain.member.repository.MemberProfileRepository;
-import io.oduck.api.global.exception.NotFoundException;
 import io.oduck.api.global.exception.UnauthorizedException;
 import io.oduck.api.global.security.auth.dto.AuthResDto.Status;
 import io.oduck.api.global.security.auth.dto.AuthUser;
@@ -32,7 +31,7 @@ public class AuthService {
 
     public Status getStatus(Long memberId) {
         MemberProfile memberProfile = memberProfileRepository.findByMemberId(memberId)
-            .orElseThrow(() -> new NotFoundException("Member"));
+            .orElseThrow(() -> new UnauthorizedException("UnAuthorized"));
 
         return Status.builder()
             .name(memberProfile.getName())
@@ -44,12 +43,11 @@ public class AuthService {
 
     public AuthLocal getAuthLocal(String email) {
         return authLocalRepository.findByEmail(email)
-            .orElseThrow(() -> new NotFoundException("Member"));
+            .orElseThrow(() -> new UnauthorizedException("UnAuthorized"));
     }
 
     public void login(LocalAuthDto localAuthDto) {
         String username = localAuthDto.getEmail();
-
 
         AuthLocal authLocal = getAuthLocal(username);
         Role role = authLocal.getMember().getRole();

--- a/src/main/java/io/oduck/api/global/utils/QueryDslUtils.java
+++ b/src/main/java/io/oduck/api/global/utils/QueryDslUtils.java
@@ -1,0 +1,43 @@
+package io.oduck.api.global.utils;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberPath;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+
+// QueryDsl 정렬 기준 생성용 클래스
+@Component
+public class QueryDslUtils {
+    // pageable에서 sort 객체로 OrderSpecifier를 생성하여 반환.
+    public OrderSpecifier[] getAllOrderSpecifiers(Pageable pageable, Path path) {
+        List<OrderSpecifier> orders = convertToDslOrder(pageable, path);
+        return orders.toArray(OrderSpecifier[]::new);
+    }
+
+    // Sort 객체에 Order가 존재할 때 QueryDSL Order로 변환
+    private static List<OrderSpecifier> convertToDslOrder(Pageable pageable, Path path) {
+        List<OrderSpecifier> orders = new ArrayList<>();
+        if (!pageable.getSort().isEmpty()) {
+            for (Sort.Order order : pageable.getSort()) {
+                Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+
+                OrderSpecifier<?> orderBy = createOrderSpecifier(direction, path, order.getProperty());
+                orders.add(orderBy);
+            }
+        }
+        return orders;
+    }
+
+    private static OrderSpecifier<?> createOrderSpecifier(Order order, Path<?> parent, String fieldName) {
+        // 일반 컬럼을 기준으로 할때의 OrderSpecifier
+        Path<Object> fieldPath = Expressions.path(Object.class, parent, fieldName);
+
+        return new OrderSpecifier(order, fieldPath);
+    }
+}

--- a/src/test/java/io/oduck/api/e2e/auth/AuthControllerTest.java
+++ b/src/test/java/io/oduck/api/e2e/auth/AuthControllerTest.java
@@ -36,7 +36,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockHttpSession;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.ActiveProfiles;
@@ -83,7 +82,7 @@ public class AuthControllerTest {
 
             // then
             actions
-                .andExpect(status().is3xxRedirection())
+                .andExpect(status().isCreated())
                 .andDo(
                     document("postLogin/success",
                         preprocessRequest(prettyPrint()),
@@ -101,8 +100,6 @@ public class AuthControllerTest {
                                     "숫자, 영문대소문자, 특수문자(!@#$%^&*()-_=+)를 포함한 8~20자리"))
                                 .description("로그인에 필요한 비밀 번호")),
                         responseHeaders(
-                            headerWithName(HttpHeaders.LOCATION) // 헤더 이름
-                                .description("Header Location, 리소스의 URL"),
                             headerWithName(HttpHeaders.SET_COOKIE) // 헤더 이름
                                 .description("Header Set-Cookie, 세션 쿠키")
                         )

--- a/src/test/java/io/oduck/api/global/config/QueryDslConfig.java
+++ b/src/test/java/io/oduck/api/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package io.oduck.api.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
## 📝 개요

QueryDsl 설정 추가.

## 🚀 변경사항
1. QueryDsl 의존성 추가.
2. QueryDsl 설정 추가.
3. QueryDsl 정렬을 위한 유틸 추가.
4. QueryDsl 테스트를 위한 설정 추가.
5. 로그인 예외 변경
6. 로그인 응답 302(redirect) -> 201(created)로 변경


## 🔗 관련 이슈

#12

## ➕ 기타
