### PR TITLE
Anime 등록, 수정 문서화 #17

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -137,3 +137,190 @@ include::{snippets}/getAnimeById/success/response-body.adoc[]
 .response-fields
 include::{snippets}/getAnimeById/success/response-fields.adoc[]
 ==== 실패 시
+
+
+== shortReview
+
+=== GET api/v1/short-review/animeId/1
+
+.curl-request
+include::{snippets}/getShortReviews/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/getShortReviews/success/http-request.adoc[]
+
+.request-param
+include::{snippets}/getShortReviews/success/path-parameters.adoc[]
+
+==== 성공시
+.http-response
+include::{snippets}/getShortReviews/success/response-fields.adoc[]
+
+.response-body
+include::{snippets}/getShortReviews/success/response-body.adoc[]
+
+.response-fields
+include::{snippets}/getShortReviews/success/response-fields.adoc[]
+
+.http-response
+include::{snippets}/getShortReviews/success/http-response.adoc[]
+==== 실패시
+
+== admin
+
+=== POST api/v1/oduckdmin/animes
+.curl-request
+include::{snippets}/postAnime/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/postAnime/success/http-request.adoc[]
+
+.request-body
+include::{snippets}/postAnime/success/request-body.adoc[]
+
+.request-fields
+include::{snippets}/postAnime/success/request-fields.adoc[]
+
+==== 성공시
+.http-response
+include::{snippets}/postAnime/success/http-response.adoc[]
+
+==== 실패시
+
+=== PATCH api/v1/oduckdmin/animes/:id
+.curl-request
+include::{snippets}/patchAnime/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/patchAnime/success/http-request.adoc[]
+
+.request-param
+include::{snippets}/patchAnime/success/path-parameters.adoc[]
+
+.request-body
+include::{snippets}/patchAnime/success/request-body.adoc[]
+
+.request-fields
+include::{snippets}/patchAnime/success/request-fields.adoc[]
+
+==== 성공시
+
+.http-response
+include::{snippets}/patchAnime/success/http-response.adoc[]
+
+==== 실패시
+
+=== PATCH api/v1/oduckdmin/animes/:id/original-authors
+.curl-request
+include::{snippets}/patchAnimeOriginalAuthors/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/patchAnimeOriginalAuthors/success/http-request.adoc[]
+
+.request-param
+include::{snippets}/patchAnimeOriginalAuthors/success/path-parameters.adoc[]
+
+.request-body
+include::{snippets}/patchAnimeOriginalAuthors/success/request-body.adoc[]
+
+.request-fields
+include::{snippets}/patchAnimeOriginalAuthors/success/request-fields.adoc[]
+
+==== 성공시
+
+.http-response
+include::{snippets}/patchAnimeOriginalAuthors/success/http-response.adoc[]
+
+==== 실패시
+
+=== PATCH api/v1/oduckdmin/animes/:id/studios
+.curl-request
+include::{snippets}/patchAnimeStudios/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/patchAnimeStudios/success/http-request.adoc[]
+
+.request-param
+include::{snippets}/patchAnimeStudios/success/path-parameters.adoc[]
+
+.request-body
+include::{snippets}/patchAnimeStudios/success/request-body.adoc[]
+
+.request-fields
+include::{snippets}/patchAnimeStudios/success/request-fields.adoc[]
+
+==== 성공시
+
+.http-response
+include::{snippets}/patchAnimeStudios/success/http-response.adoc[]
+
+==== 실패시
+
+=== PATCH api/v1/oduckdmin/animes/:id/voice-actors
+.curl-request
+include::{snippets}/patchAnimeVoiceActors/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/patchAnimeVoiceActors/success/http-request.adoc[]
+
+.request-param
+include::{snippets}/patchAnimeVoiceActors/success/path-parameters.adoc[]
+
+.request-body
+include::{snippets}/patchAnimeVoiceActors/success/request-body.adoc[]
+
+.request-fields
+include::{snippets}/patchAnimeVoiceActors/success/request-fields.adoc[]
+
+==== 성공시
+
+.http-response
+include::{snippets}/patchAnimeVoiceActors/success/http-response.adoc[]
+
+==== 실패시
+
+=== PATCH api/v1/oduckdmin/animes/:id/genres
+.curl-request
+include::{snippets}/patchAnimeGenres/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/patchAnimeGenres/success/http-request.adoc[]
+
+.request-param
+include::{snippets}/patchAnimeGenres/success/path-parameters.adoc[]
+
+.request-body
+include::{snippets}/patchAnimeGenres/success/request-body.adoc[]
+
+.request-fields
+include::{snippets}/patchAnimeGenres/success/request-fields.adoc[]
+
+==== 성공시
+
+.http-response
+include::{snippets}/patchAnimeGenres/success/http-response.adoc[]
+
+==== 실패시
+
+=== PATCH api/v1/oduckdmin/animes/:id/series
+.curl-request
+include::{snippets}/patchAnimeSeries/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/patchAnimeSeries/success/http-request.adoc[]
+
+.request-param
+include::{snippets}/patchAnimeSeries/success/path-parameters.adoc[]
+
+.request-body
+include::{snippets}/patchAnimeSeries/success/request-body.adoc[]
+
+.request-fields
+include::{snippets}/patchAnimeSeries/success/request-fields.adoc[]
+
+==== 성공시
+
+.http-response
+include::{snippets}/patchAnimeSeries/success/http-response.adoc[]
+
+==== 실패시

--- a/src/main/java/io/oduck/api/domain/admin/controller/AdminController.java
+++ b/src/main/java/io/oduck/api/domain/admin/controller/AdminController.java
@@ -1,0 +1,154 @@
+package io.oduck.api.domain.admin.controller;
+
+import static io.oduck.api.domain.anime.dto.AnimeReq.PatchAnimeReq;
+import static io.oduck.api.domain.anime.dto.AnimeReq.PostReq;
+
+import io.oduck.api.domain.anime.dto.AnimeReq.PatchGenreIdsReq;
+import io.oduck.api.domain.anime.dto.AnimeReq.PatchOriginalAuthorIdsReq;
+import io.oduck.api.domain.anime.dto.AnimeReq.PatchSeriesIdReq;
+import io.oduck.api.domain.anime.dto.AnimeReq.PatchStudioIdsReq;
+import io.oduck.api.domain.anime.dto.AnimeReq.PatchVoiceActorIdsReq;
+import io.oduck.api.domain.anime.entity.AnimeGenre;
+import io.oduck.api.domain.anime.entity.AnimeOriginalAuthor;
+import io.oduck.api.domain.anime.entity.AnimeStudio;
+import io.oduck.api.domain.anime.entity.AnimeVoiceActor;
+import io.oduck.api.domain.anime.service.AnimeService;
+import io.oduck.api.domain.series.entity.Series;
+import jakarta.validation.Valid;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/oduckdmin")
+@Slf4j
+public class AdminController {
+
+    private final AnimeService animeService;
+
+    //애니 등록
+    @PostMapping("/animes")
+    public ResponseEntity<Object> postAnime(@RequestBody @Valid PostReq req){
+        // TODO: 애니 추가 로직 구현
+        animeService.save(req);
+
+        return ResponseEntity.ok().build();
+    }
+
+    //애니 관련 수정
+    @PatchMapping("/animes/{animeId}")
+    public ResponseEntity<Object> patchAnime(
+        @PathVariable Long animeId, @RequestBody @Valid PatchAnimeReq req
+    ){
+        //TODO: 애니 수정 로직 구현
+        animeService.update(animeId, req);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    // 애니의 원작 작가 수정
+    @PatchMapping("/animes/{animeId}/original-authors")
+    public ResponseEntity<Object> patchAnimeOriginalAuthors(
+        @PathVariable Long animeId, @RequestBody PatchOriginalAuthorIdsReq req
+    ){
+        List<Long> originalAuthorIds = req.getOriginalAuthorIds();
+        //TODO: 컨트롤러에서 애니 아이디와 원작 작가 아이디로 AnimeOriginalAuthor들을 찾아야 함.
+        List<AnimeOriginalAuthor> animeOriginalAuthors = new ArrayList<>();
+
+        //TODO: 애니 수정 로직 구현
+        animeService.updateAnimeOriginalAuthors(animeId, animeOriginalAuthors);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    // 애니의 스튜디오 수정
+    @PatchMapping("/animes/{animeId}/studios")
+    public ResponseEntity<Object> patchAnimeStudios(
+        @PathVariable Long animeId, @RequestBody PatchStudioIdsReq req
+    ){
+        List<Long> originalAuthorIds = req.getStudioIds();
+        //TODO: 컨트롤러에서 애니 아이디와 원작 작가 아이디로 AnimeOriginalAuthor들을 찾아야 함.
+        List<AnimeStudio> animeStudios = new ArrayList<>();
+
+        //TODO: 애니 수정 로직 구현
+        animeService.updateAnimeStudios(animeId, animeStudios);
+
+        return ResponseEntity.noContent().build();
+    }
+    // 애니의 성우 수정
+    @PatchMapping("/animes/{animeId}/voice-actors")
+    public ResponseEntity<Object> patchAnimeVoiceActors(
+        @PathVariable Long animeId, @RequestBody PatchVoiceActorIdsReq req
+    ){
+        List<Long> voiceActorIds = req.getVoiceActorIds();
+        //TODO: 컨트롤러에서 애니 아이디와 성우 아이디로 AnimeOriginalAuthor들을 찾아야 함.
+        List<AnimeVoiceActor> animeVoiceActors = new ArrayList<>();
+
+        //TODO: 애니 수정 로직 구현
+        animeService.updateAnimeVoiceActors(animeId, animeVoiceActors);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    // 애니의 장르 수정
+    @PatchMapping("/animes/{animeId}/genres")
+    public ResponseEntity<Object> patchAnimeGenres(
+        @PathVariable Long animeId, @RequestBody PatchGenreIdsReq req
+    ){
+        List<Long> genreIds = req.getGenreIds();
+        //TODO: 컨트롤러에서 애니 아이디와 장르 아이디로 AnimeGenre들을 찾아야 함.
+        List<AnimeGenre> animeGenres = new ArrayList<>();
+
+        //TODO: 애니 수정 로직 구현
+        animeService.updateAnimeGenres(animeId, animeGenres);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    // 애니의 시리즈 수정
+    @PatchMapping("/animes/{animeId}/series")
+    public ResponseEntity<Object> patchAnimeSeries(
+        @PathVariable Long animeId, @RequestBody PatchSeriesIdReq req
+    ){
+        Long seriesId = req.getSeriesId();
+        //TODO: 컨트롤러에서 시리즈 아이디로 시리즈를 찾아야 함.
+        Series series = null;
+
+        //TODO: 애니 수정 로직 구현
+        animeService.update(animeId, series);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    // 애니 삭제
+//    @DeleteMapping("/animes/{animeId}")
+//    public ResponseEntity<Object> deleteAnime(@PathVariable Long animeId){
+//
+//        //TODO: 애니 삭제 로직 구현. (애니를 실제로 삭제하지 않음)
+//        animeService.delete(animeId);
+//        return ResponseEntity.noContent().build();
+//    }
+
+//     관리자 애니 조회 (isReleased = false도 조회)
+//    @GetMapping("/animes")
+//    public ResponseEntity<Object> getAnimes(
+//        Pageable pageable, String query, SearchCondition condition
+//    ){
+//
+//        //TODO: 애니 조회 로직 구현.
+//        Page<GetAnime> res = adminAnimeService.getAnimes(pageable, query, condition);
+//        return ResponseEntity
+//            .ok(PageResponse.of(null));
+//    }
+}

--- a/src/main/java/io/oduck/api/domain/anime/controller/AnimeController.java
+++ b/src/main/java/io/oduck/api/domain/anime/controller/AnimeController.java
@@ -2,7 +2,6 @@ package io.oduck.api.domain.anime.controller;
 
 import io.oduck.api.domain.anime.dto.AnimeRes;
 import io.oduck.api.domain.anime.service.AnimeService;
-import io.oduck.api.global.common.SingleResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -28,7 +27,7 @@ public class AnimeController {
         // TODO: 애니 조회 로직 구현
         AnimeRes res = animeService.getAnimeById(animeId);
         return ResponseEntity
-            .ok(SingleResponse.of(res));
+            .ok(res);
     }
 
     // TODO: 애니 검색 결과 페이징

--- a/src/main/java/io/oduck/api/domain/anime/dto/AnimeReq.java
+++ b/src/main/java/io/oduck/api/domain/anime/dto/AnimeReq.java
@@ -1,0 +1,200 @@
+package io.oduck.api.domain.anime.dto;
+
+import io.oduck.api.domain.anime.entity.BroadcastType;
+import io.oduck.api.domain.anime.entity.Quarter;
+import io.oduck.api.domain.anime.entity.Rating;
+import io.oduck.api.domain.anime.entity.Status;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+public class AnimeReq {
+
+    @Getter
+    public static class PostReq {
+        @NotBlank
+        @Length(min = 1, max = 50,
+            message = "글자 수는 0~50을 허용합니다.")
+        private String title;
+
+        @NotBlank
+        @Length(min = 1, max = 255,
+            message = "글자 수는 0~255를 허용합니다.")
+        private String summary;
+
+        private BroadcastType broadcastType;
+
+        @Min(value = 0,
+            message = "음수가 올 수 없습니다.")
+        private int episodeCount;
+
+        @NotBlank(
+            message = "섬네일을 입력하세요.")
+        private String thumbnail;
+
+        @Min(value = 1900,
+            message = "1900년대 이상을 입력하세요.")
+        private int year;
+
+        private Quarter quarter;
+
+        private Rating rating;
+
+        private Status status;
+
+        private List<Long> originalAuthorIds;
+
+        private List<Long> studioIds;
+
+        private List<Long> voiceActorIds;
+
+        private List<Long> genreIds;
+
+        private Long seriesId;
+
+        public PostReq (String title, String summary, BroadcastType broadcastType,
+            int episodeCount, String thumbnail, int year, Quarter quarter, Rating rating, Status status,
+            List<Long> originalAuthorIds, List<Long> studioIds, List<Long> voiceActorIds,
+            List<Long> genreIds, Long seriesId) {
+
+            this.title = title;
+            this.summary = summary;
+            this.broadcastType = broadcastType;
+            this.episodeCount = episodeCount;
+            this.thumbnail = thumbnail;
+            this.year = year;
+            this.quarter = quarter;
+            this.rating = rating;
+            this.status = status;
+
+            if(originalAuthorIds == null){
+                this.originalAuthorIds = new ArrayList<>();
+            }else {
+                this.originalAuthorIds = originalAuthorIds;
+            }
+
+            if(studioIds == null){
+                this.studioIds = new ArrayList<>();
+            }else{
+                this.studioIds = studioIds;
+            }
+
+            if(voiceActorIds == null) {
+                this.voiceActorIds = new ArrayList<>();
+            }else {
+                this.voiceActorIds = voiceActorIds;
+            }
+
+            if(genreIds == null) {
+                this.genreIds = new ArrayList<>();
+            }else {
+                this.genreIds = genreIds;
+            }
+
+            this.seriesId = seriesId;
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class PatchAnimeReq{
+        @NotBlank
+        @Length(min = 1, max = 50,
+            message = "글자 수는 0~50을 허용합니다.")
+        private String title;
+
+        @NotBlank
+        @Length(min = 1, max = 255,
+            message = "글자 수는 0~255를 허용합니다.")
+        private String summary;
+
+        private BroadcastType broadcastType;
+
+        @Min(value = 0,
+            message = "음수가 올 수 없습니다.")
+        private int episodeCount;
+
+        @NotBlank(
+            message = "섬네일을 입력하세요.")
+        private String thumbnail;
+
+        @Min(value = 1900,
+            message = "1900년대 이상을 입력하세요.")
+        private int year;
+
+        private Quarter quarter;
+
+        private Rating rating;
+
+        private Status status;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class PatchOriginalAuthorIdsReq {
+        private List<Long> originalAuthorIds;
+
+        public PatchOriginalAuthorIdsReq(List<Long> originalAuthorIds) {
+            if(originalAuthorIds == null){
+                this.originalAuthorIds = new ArrayList<>();
+            }else{
+                this.originalAuthorIds = originalAuthorIds;
+            }
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class PatchStudioIdsReq {
+        private List<Long> studioIds;
+
+        public PatchStudioIdsReq(List<Long> studioIds) {
+            if(studioIds == null){
+                this.studioIds = new ArrayList<>();
+            }else{
+                this.studioIds = studioIds;
+            }
+        }
+
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class PatchVoiceActorIdsReq {
+        private List<Long> voiceActorIds;
+
+        public PatchVoiceActorIdsReq(List<Long> voiceActorIds) {
+            if(voiceActorIds == null){
+                this.voiceActorIds = new ArrayList<>();
+            }else{
+                this.voiceActorIds = voiceActorIds;
+            }
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class PatchGenreIdsReq {
+        private List<Long> genreIds;
+
+        public PatchGenreIdsReq(List<Long> genreIds) {
+            if(genreIds == null){
+                this.genreIds = new ArrayList<>();
+            }else{
+                this.genreIds = genreIds;
+            }
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class PatchSeriesIdReq{
+        private Long seriesId;
+    }
+}

--- a/src/main/java/io/oduck/api/domain/anime/dto/AnimeRes.java
+++ b/src/main/java/io/oduck/api/domain/anime/dto/AnimeRes.java
@@ -16,10 +16,12 @@ public class AnimeRes {
     @Getter
     @Builder
     public static class Anime {
-        private Long animeId;
+        private Long id;
         private String title;
         private String thumbnail;
-        private Broadcast broadcast;
+        private BroadcastType broadcastType;
+        private int year;
+        private Quarter quarter;
         private String summary;
         private int episodeCount;
         private Rating rating;
@@ -31,13 +33,5 @@ public class AnimeRes {
         private List<String> studios;
         private long reviewCount;
         private long bookmarkCount;
-    }
-
-    @Getter
-    @Builder
-    public static class Broadcast {
-        private BroadcastType broadcastType;
-        private int year;
-        private Quarter quarter;
     }
 }

--- a/src/main/java/io/oduck/api/domain/anime/entity/Anime.java
+++ b/src/main/java/io/oduck/api/domain/anime/entity/Anime.java
@@ -31,7 +31,7 @@ public class Anime extends BaseEntity {
   @Column(nullable = false, length = 50)
   private String title;
 
-  @Column(nullable = false, length = 255)
+  @Column(nullable = false, length = 600)
   private String summary;
 
   @Enumerated(EnumType.STRING)
@@ -43,6 +43,7 @@ public class Anime extends BaseEntity {
   @Column(nullable = true, length = 500)
   private String thumbnail;
 
+  @Column(name = "release_year")
   private int year;
 
   @Enumerated(EnumType.STRING)

--- a/src/main/java/io/oduck/api/domain/anime/service/AnimeService.java
+++ b/src/main/java/io/oduck/api/domain/anime/service/AnimeService.java
@@ -1,6 +1,13 @@
 package io.oduck.api.domain.anime.service;
 
+import io.oduck.api.domain.anime.dto.AnimeReq.*;
 import io.oduck.api.domain.anime.dto.AnimeRes;
+import io.oduck.api.domain.anime.entity.AnimeGenre;
+import io.oduck.api.domain.anime.entity.AnimeOriginalAuthor;
+import io.oduck.api.domain.anime.entity.AnimeStudio;
+import io.oduck.api.domain.anime.entity.AnimeVoiceActor;
+import io.oduck.api.domain.series.entity.Series;
+import java.util.List;
 
 public interface AnimeService {
 
@@ -10,4 +17,53 @@ public interface AnimeService {
      * @return AnimeRes
      */
     AnimeRes getAnimeById(Long animeId);
+
+    /**
+     * 애니 저장 로직
+     * @param req
+     * @return AnimeId
+     */
+    Long save(PostReq req);
+
+    /**
+     * 애니 수정 로직
+     * @param animeId
+     * @param req
+     */
+    void update(Long animeId, PatchAnimeReq req);
+
+    /**
+     * 애니 원작 작가 수정 로직
+     * @param animeId
+     * @param originalAuthors
+     */
+    void updateAnimeOriginalAuthors(Long animeId, List<AnimeOriginalAuthor> originalAuthors);
+
+    /**
+     * 애니 스튜디오 수정 로직
+     * @param animeId
+     * @param animeStudios
+     */
+    void updateAnimeStudios(Long animeId, List<AnimeStudio> animeStudios);
+
+    /**
+     * 애니 성우 수정 로직
+     * @param animeId
+     * @param animeVoiceActors
+     */
+    void updateAnimeVoiceActors(Long animeId, List<AnimeVoiceActor> animeVoiceActors);
+
+    /**
+     * 애니 장르 수정 로직
+     * @param animeId
+     * @param animeGenres
+     */
+    void updateAnimeGenres(Long animeId, List<AnimeGenre> animeGenres);
+
+    /**
+     * 애니 시리즈 수정 로직
+     * @param animeId
+     * @param series
+     */
+    void update(Long animeId, Series series);
 }

--- a/src/main/java/io/oduck/api/domain/anime/service/AnimeServiceStub.java
+++ b/src/main/java/io/oduck/api/domain/anime/service/AnimeServiceStub.java
@@ -2,7 +2,10 @@ package io.oduck.api.domain.anime.service;
 
 import io.oduck.api.domain.anime.dto.AnimeRes;
 import io.oduck.api.domain.anime.dto.AnimeRes.Anime;
-import io.oduck.api.domain.anime.dto.AnimeRes.Broadcast;
+import io.oduck.api.domain.anime.entity.AnimeGenre;
+import io.oduck.api.domain.anime.entity.AnimeOriginalAuthor;
+import io.oduck.api.domain.anime.entity.AnimeStudio;
+import io.oduck.api.domain.anime.entity.AnimeVoiceActor;
 import io.oduck.api.domain.anime.entity.BroadcastType;
 import io.oduck.api.domain.anime.entity.Quarter;
 import io.oduck.api.domain.anime.entity.Rating;
@@ -25,10 +28,12 @@ public class AnimeServiceStub implements AnimeService{
 
     private Anime createAnime(Long animeId) {
         return Anime.builder()
-            .animeId(animeId)
+            .id(animeId)
             .title("귀멸의 칼날: 도공 마을편")
             .thumbnail("https://image파일경로/uuid.jpg")
-            .broadcast(getBroadcast())
+            .broadcastType(BroadcastType.TVA)
+            .year(2023)
+            .quarter(Quarter.Q2)
             .summary(
                 "113년 만에 상현 혈귀가 죽자 분개한 무잔은 나머지 상현 혈귀들에게 또 다른 명령을 내린다! 한편, 규타로와의 전투 도중 검이 심하게 손상된 탄지로에게 하가네즈카는 대 격노하고 탄지로는 그 검을 만든 대장장이 하가네즈카 호타루에게 검이 어떻게 심하게 손상되었는지 설명하기 위해 도공 마을을 방문한다. 탄지로가 검이 수리되기를 기다리는 동안, 상현 혈귀 한텐구와 쿗코가 숨겨진 마을인 ‘도공 마을'을 습격한다. 공격할 때마다 분열해서 위력이 커지는 한텐구로 인해 탄지로와 겐야는 고전을 면치 못한다. 한편, 타인에 대한 관심이 희박한 하주 토키토 무이치로는 혈귀들에게 공격당하고 있는 코테츠를 목격하는데….")
             .episodeCount(11)
@@ -41,15 +46,6 @@ public class AnimeServiceStub implements AnimeService{
             .reviewCount(172)
             .bookmarkCount(72)
             .build();
-    }
-
-    private Broadcast getBroadcast() {
-        return Broadcast.builder()
-            .broadcastType(BroadcastType.TVA)
-            .year(2023)
-            .quarter(Quarter.Q2)
-            .build();
-
     }
 
     private List<String> getStudios() {

--- a/src/main/java/io/oduck/api/domain/anime/service/AnimeServiceStub.java
+++ b/src/main/java/io/oduck/api/domain/anime/service/AnimeServiceStub.java
@@ -1,5 +1,7 @@
 package io.oduck.api.domain.anime.service;
 
+import io.oduck.api.domain.anime.dto.AnimeReq.PatchAnimeReq;
+import io.oduck.api.domain.anime.dto.AnimeReq.PostReq;
 import io.oduck.api.domain.anime.dto.AnimeRes;
 import io.oduck.api.domain.anime.dto.AnimeRes.Anime;
 import io.oduck.api.domain.anime.entity.AnimeGenre;
@@ -10,6 +12,7 @@ import io.oduck.api.domain.anime.entity.BroadcastType;
 import io.oduck.api.domain.anime.entity.Quarter;
 import io.oduck.api.domain.anime.entity.Rating;
 import io.oduck.api.domain.anime.entity.Status;
+import io.oduck.api.domain.series.entity.Series;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -18,12 +21,47 @@ import org.springframework.stereotype.Service;
 public class AnimeServiceStub implements AnimeService{
 
     @Override
+    public Long save(PostReq req) {
+        return 1L;
+    }
+
+    @Override
     public AnimeRes getAnimeById(Long animeId) {
         Anime anime = createAnime(animeId);
 
         return AnimeRes.builder()
             .anime(anime)
             .build();
+    }
+
+    @Override
+    public void update(Long animeId, PatchAnimeReq req) {
+
+    }
+
+    @Override
+    public void updateAnimeOriginalAuthors(Long animeId, List<AnimeOriginalAuthor> originalAuthors) {
+
+    }
+
+    @Override
+    public void updateAnimeStudios(Long animeId, List<AnimeStudio> animeStudios) {
+
+    }
+
+    @Override
+    public void updateAnimeVoiceActors(Long animeId, List<AnimeVoiceActor> animeVoiceActors) {
+
+    }
+
+    @Override
+    public void updateAnimeGenres(Long animeId, List<AnimeGenre> animeGenres) {
+
+    }
+
+    @Override
+    public void update(Long animeId, Series series) {
+
     }
 
     private Anime createAnime(Long animeId) {

--- a/src/test/java/io/oduck/api/e2e/admin/AdminControllerTest.java
+++ b/src/test/java/io/oduck/api/e2e/admin/AdminControllerTest.java
@@ -1,0 +1,410 @@
+package io.oduck.api.e2e.admin;
+
+import static io.oduck.api.global.config.RestDocsConfig.field;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.snippet.Attributes.attributes;
+import static org.springframework.restdocs.snippet.Attributes.key;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.google.gson.Gson;
+import io.oduck.api.domain.anime.dto.AnimeReq.PatchAnimeReq;
+import io.oduck.api.domain.anime.dto.AnimeReq.PatchGenreIdsReq;
+import io.oduck.api.domain.anime.dto.AnimeReq.PatchOriginalAuthorIdsReq;
+import io.oduck.api.domain.anime.dto.AnimeReq.PatchSeriesIdReq;
+import io.oduck.api.domain.anime.dto.AnimeReq.PatchStudioIdsReq;
+import io.oduck.api.domain.anime.dto.AnimeReq.PatchVoiceActorIdsReq;
+import io.oduck.api.domain.anime.dto.AnimeReq.PostReq;
+import io.oduck.api.global.utils.AnimeTestUtils;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc
+@ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
+@SpringBootTest
+@ActiveProfiles("test")
+public class AdminControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private Gson gson;
+
+    private final static String ADMIN_URL = "/oduckdmin";
+
+    @Nested
+    @DisplayName("애니 등록")
+    class PostAnime{
+
+        @Test
+        @DisplayName("등록 성공 시 Http Status 200 반환")
+        void postAnime() throws Exception {
+            //given
+            PostReq request = AnimeTestUtils.createPostAnimeRequest();
+            String content = gson.toJson(request);
+
+            //when
+            ResultActions actions = mockMvc.perform(
+                post(ADMIN_URL+"/animes")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .content(content)
+            );
+
+            //then
+            actions
+                .andExpect(status().isOk())
+                .andDo(document("postAnime/success",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    requestFields(attributes(key("title").value("Fields for anime creation")),
+                        fieldWithPath("title")
+                            .type(JsonFieldType.STRING)
+                            .attributes(field("constraints", "공백을 허용하지 않습니다. 1~50자를 허용합니다."))
+                            .description("애니의 제목"),
+                        fieldWithPath("summary")
+                            .type(JsonFieldType.STRING)
+                            .attributes(field("constraints", "공백을 허용하지 않습니다. 1~255자를 허용합니다."))
+                            .description("애니 요약 설명"),
+                        fieldWithPath("broadcastType")
+                            .type(JsonFieldType.STRING)
+                            .attributes(field("constraints", "TVA,ONA,OVA,MOV만 허용합니다."))
+                            .description("애니 방송사"),
+                        fieldWithPath("episodeCount")
+                            .type(JsonFieldType.NUMBER)
+                            .attributes(field("constraints", "0 이상의 숫자만 허용합니다."))
+                            .description("애피소드 화수"),
+                        fieldWithPath("thumbnail")
+                            .type(JsonFieldType.STRING)
+                            .attributes(field("constraints", "공백을 허용하지 않습니다."))
+                            .description("애피소드 화수"),
+                        fieldWithPath("year")
+                            .type(JsonFieldType.NUMBER)
+                            .attributes(field("constraints", "1900 이상의 숫자만 허용합니다."))
+                            .description("애니 발행 년도"),
+                        fieldWithPath("quarter")
+                            .type(JsonFieldType.STRING)
+                            .attributes(field("constraints", "Q1,Q2,Q3,Q4만 허용합니다."))
+                            .description("애니 발행 분기"),
+                        fieldWithPath("rating")
+                            .type(JsonFieldType.STRING)
+                            .attributes(field("constraints", "ADULT,FIFTEEN,TWELVE,ALL만 허용합니다."))
+                            .description("애니 등급"),
+                        fieldWithPath("status")
+                            .type(JsonFieldType.STRING)
+                            .attributes(field("constraints", "ONGOING,FINISHED,UPCOMING,UNKNOWN만 허용합니다."))
+                            .description("애니 상태"),
+                        fieldWithPath("originalAuthorIds")
+                            .type(JsonFieldType.ARRAY)
+                            .description("원작 작가들 아이디 리스트")
+                            .attributes(field("constraints", "List만 허용합니다."))
+                            .optional(),
+                        fieldWithPath("studioIds")
+                            .type(JsonFieldType.ARRAY)
+                            .description("애니 스튜디오 아이디 리스트")
+                            .attributes(field("constraints", "List만 허용합니다."))
+                            .optional(),
+                        fieldWithPath("voiceActorIds")
+                            .type(JsonFieldType.ARRAY)
+                            .description("애니 성우 아이디 리스트")
+                            .attributes(field("constraints", "List만 허용합니다."))
+                            .optional(),
+                        fieldWithPath("genreIds")
+                            .type(JsonFieldType.ARRAY)
+                            .description("애니 장르 아이디 리스트")
+                            .attributes(field("constraints", "List만 허용합니다."))
+                            .optional(),
+                        fieldWithPath("seriesId")
+                            .type(JsonFieldType.NUMBER)
+                            .description("애니 시리즈 아이디")
+                            .attributes(field("constraints", "숫자만 허용합니다."))
+                            .optional()
+                    )
+                ));
+        }
+        //TODO : 애니 등록 실패 시
+    }
+
+    @Nested
+    @DisplayName("애니 수정")
+    class PatchAnime{
+
+        @Test
+        @DisplayName("애니 수정 성공 시 Http Status 204 반환")
+        void patchAnime() throws Exception {
+            //given
+            Long animeId = 1L;
+            PatchAnimeReq req = AnimeTestUtils.createPatchAnimeRequest();
+            String content = gson.toJson(req);
+
+            //when
+            ResultActions actions = mockMvc.perform(
+                patch(ADMIN_URL+"/animes/{animeId}", animeId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .content(content)
+            );
+
+            //then
+            actions
+                .andExpect(status().isNoContent())
+                .andDo(document("patchAnime/success",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("animeId").description("애니의 식별자")
+                    ),
+                    requestFields(attributes(key("title").value("Fields for anime creation")),
+                        fieldWithPath("title")
+                            .type(JsonFieldType.STRING)
+                            .attributes(field("constraints", "공백을 허용하지 않습니다. 1~50자를 허용합니다."))
+                            .description("애니의 제목"),
+                        fieldWithPath("summary")
+                            .type(JsonFieldType.STRING)
+                            .attributes(field("constraints", "공백을 허용하지 않습니다. 1~255자를 허용합니다."))
+                            .description("애니 요약 설명"),
+                        fieldWithPath("broadcastType")
+                            .type(JsonFieldType.STRING)
+                            .attributes(field("constraints", "TVA,ONA,OVA,MOV만 허용합니다."))
+                            .description("애니 방송사"),
+                        fieldWithPath("episodeCount")
+                            .type(JsonFieldType.NUMBER)
+                            .attributes(field("constraints", "0 이상의 숫자만 허용합니다."))
+                            .description("애피소드 화수"),
+                        fieldWithPath("thumbnail")
+                            .type(JsonFieldType.STRING)
+                            .attributes(field("constraints", "공백을 허용하지 않습니다."))
+                            .description("애피소드 화수"),
+                        fieldWithPath("year")
+                            .type(JsonFieldType.NUMBER)
+                            .attributes(field("constraints", "1900 이상의 숫자만 허용합니다."))
+                            .description("애니 발행 년도"),
+                        fieldWithPath("quarter")
+                            .type(JsonFieldType.STRING)
+                            .attributes(field("constraints", "Q1,Q2,Q3,Q4만 허용합니다."))
+                            .description("애니 발행 분기"),
+                        fieldWithPath("rating")
+                            .type(JsonFieldType.STRING)
+                            .attributes(field("constraints", "ADULT,FIFTEEN,TWELVE,ALL만 허용합니다."))
+                            .description("애니 등급"),
+                        fieldWithPath("status")
+                            .type(JsonFieldType.STRING)
+                            .attributes(field("constraints", "ONGOING,FINISHED,UPCOMING,UNKNOWN만 허용합니다."))
+                            .description("애니 상태")
+                    )
+                ));
+
+        }
+        //TODO: 수정 실패 시
+
+        @Test
+        @DisplayName("애니 원작 작가 수정 성공 시 Http Status 204 반환")
+        void patchAnimeOriginalAuthors() throws Exception {
+            //given
+            Long animeId = 1L;
+            List<Long> originalAuthorIds = AnimeTestUtils.getOriginalAuthorIds();
+
+            PatchOriginalAuthorIdsReq req = new PatchOriginalAuthorIdsReq(originalAuthorIds);
+            String content = gson.toJson(req);
+
+            //when
+            ResultActions actions = mockMvc.perform(
+                patch(ADMIN_URL+"/animes/{animeId}/original-authors", animeId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .content(content)
+            );
+
+            //then
+            actions
+                .andDo(document("patchAnimeOriginalAuthors/success",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("animeId").description("애니의 식별자")
+                    ),
+                    requestFields(attributes(key("title").value("Fields for anime creation")),
+                        fieldWithPath("originalAuthorIds")
+                            .type(JsonFieldType.ARRAY)
+                            .description("원작 작가들 아이디 리스트")
+                            .attributes(field("constraints", "List만 허용합니다."))
+                            .optional()
+                    )
+                ));
+
+        }
+        //TODO: 수정 실패 시
+
+        @Test
+        @DisplayName("애니 원작 작가 수정 성공 시 Http Status 204 반환")
+        void patchAnimeStudios() throws Exception {
+            //given
+            Long animeId = 1L;
+            List<Long> studioIds = AnimeTestUtils.getStudioIds();
+
+            PatchStudioIdsReq req = new PatchStudioIdsReq(studioIds);
+            String content = gson.toJson(req);
+
+            //when
+            ResultActions actions = mockMvc.perform(
+                patch(ADMIN_URL+"/animes/{animeId}/studios", animeId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .content(content)
+            );
+
+            //then
+            actions
+                .andDo(document("patchAnimeStudios/success",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("animeId").description("애니의 식별자")
+                    ),
+                    requestFields(attributes(key("title").value("Fields for anime creation")),
+                        fieldWithPath("studioIds")
+                            .type(JsonFieldType.ARRAY)
+                            .description("스튜디오 아이디 리스트")
+                            .attributes(field("constraints", "List만 허용합니다."))
+                            .optional()
+                    )
+                ));
+
+        }
+        //TODO: 수정 실패 시
+
+        @Test
+        @DisplayName("애니 성우 수정 성공 시 Http Status 204 반환")
+        void patchAnimeVoiceActors() throws Exception {
+            //given
+            Long animeId = 1L;
+            List<Long> voiceActorIds = AnimeTestUtils.getVoiceActorIds();
+
+            PatchVoiceActorIdsReq req = new PatchVoiceActorIdsReq(voiceActorIds);
+            String content = gson.toJson(req);
+
+            //when
+            ResultActions actions = mockMvc.perform(
+                put(ADMIN_URL+"/animes/{animeId}/voice-actors", animeId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .content(content)
+            );
+
+            //then
+            actions
+                .andDo(document("patchAnimeVoiceActors/success",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("animeId").description("애니의 식별자")
+                    ),
+                    requestFields(attributes(key("title").value("Fields for anime creation")),
+                        fieldWithPath("voiceActorIds")
+                            .type(JsonFieldType.ARRAY)
+                            .description("애니 성우 아이디 리스트")
+                            .attributes(field("constraints", "List만 허용합니다."))
+                            .optional()
+                    )
+                ));
+        }
+        //TODO: 수정 실패 시
+
+        @Test
+        @DisplayName("애니 장르 수정 성공 시 Http Status 204 반환")
+        void patchAnimeGenres() throws Exception {
+            //given
+            Long animeId = 1L;
+            List<Long> genreIds = AnimeTestUtils.getGenreIds();
+
+            PatchGenreIdsReq req = new PatchGenreIdsReq(genreIds);
+            String content = gson.toJson(req);
+
+            //when
+            ResultActions actions = mockMvc.perform(
+                put(ADMIN_URL+"/animes/{animeId}/genres", animeId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .content(content)
+            );
+
+            //then
+            actions
+                .andDo(document("patchAnimeGenres/success",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("animeId").description("애니의 식별자")
+                    ),
+                    requestFields(attributes(key("title").value("Fields for anime creation")),
+                        fieldWithPath("genreIds")
+                            .type(JsonFieldType.ARRAY)
+                            .description("애니 장르 아이디 리스트")
+                            .attributes(field("constraints", "List만 허용합니다."))
+                            .optional()
+                    )
+                ));
+        }
+        //TODO: 수정 실패 시
+
+        @Test
+        @DisplayName("애니의 시리즈 수정 성공 시 Http Status 204 반환")
+        void patchAnimeSeries() throws Exception {
+            //given
+            Long animeId = 1L;
+            PatchSeriesIdReq req = new PatchSeriesIdReq(AnimeTestUtils.getSeriesId());
+            String content = gson.toJson(req);
+
+            //when
+            ResultActions actions = mockMvc.perform(
+                patch(ADMIN_URL+"/animes/{animeId}/series", animeId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .content(content)
+            );
+
+            //then
+            actions
+                .andExpect(status().isNoContent())
+                .andDo(document("patchAnimeSeries/success",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("animeId").description("애니의 식별자")
+                    ),
+                    requestFields(attributes(key("title").value("Fields for anime creation")),
+                        fieldWithPath("seriesId")
+                            .type(JsonFieldType.NUMBER)
+                            .description("애니 시리즈 아이디")
+                            .attributes(field("constraints", "숫자만 허용합니다."))
+                            .optional()
+                    )
+                ));
+        }
+        //TODO: 수정 실패 시
+    }
+}

--- a/src/test/java/io/oduck/api/e2e/anime/AnimeControllerTest.java
+++ b/src/test/java/io/oduck/api/e2e/anime/AnimeControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -26,7 +27,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 @AutoConfigureRestDocs
 @AutoConfigureMockMvc
@@ -57,22 +57,23 @@ public class AnimeControllerTest {
 
             //then
             actions
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(jsonPath("$.item.anime.title").exists())
-                .andExpect(jsonPath("$.item.anime.thumbnail").exists())
-                .andExpect(jsonPath("$.item.anime.broadcast.broadcastType").exists())
-                .andExpect(jsonPath("$.item.anime.broadcast.year").exists())
-                .andExpect(jsonPath("$.item.anime.broadcast.quarter").exists())
-                .andExpect(jsonPath("$.item.anime.summary").exists())
-                .andExpect(jsonPath("$.item.anime.episodeCount").exists())
-                .andExpect(jsonPath("$.item.anime.rating").exists())
-                .andExpect(jsonPath("$.item.anime.status").exists())
-                .andExpect(jsonPath("$.item.anime.genres").exists())
-                .andExpect(jsonPath("$.item.anime.originalAuthors").exists())
-                .andExpect(jsonPath("$.item.anime.voiceActors").exists())
-                .andExpect(jsonPath("$.item.anime.studios").exists())
-                .andExpect(jsonPath("$.item.anime.reviewCount").exists())
-                .andExpect(jsonPath("$.item.anime.bookmarkCount").exists())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.anime.id").exists())
+                .andExpect(jsonPath("$.anime.title").exists())
+                .andExpect(jsonPath("$.anime.thumbnail").exists())
+                .andExpect(jsonPath("$.anime.broadcastType").exists())
+                .andExpect(jsonPath("$.anime.year").exists())
+                .andExpect(jsonPath("$.anime.quarter").exists())
+                .andExpect(jsonPath("$.anime.summary").exists())
+                .andExpect(jsonPath("$.anime.episodeCount").exists())
+                .andExpect(jsonPath("$.anime.rating").exists())
+                .andExpect(jsonPath("$.anime.status").exists())
+                .andExpect(jsonPath("$.anime.genres").exists())
+                .andExpect(jsonPath("$.anime.originalAuthors").exists())
+                .andExpect(jsonPath("$.anime.voiceActors").exists())
+                .andExpect(jsonPath("$.anime.studios").exists())
+                .andExpect(jsonPath("$.anime.reviewCount").exists())
+                .andExpect(jsonPath("$.anime.bookmarkCount").exists())
                 .andDo(document("getAnimeById/success",
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
@@ -81,61 +82,55 @@ public class AnimeControllerTest {
                             .description("애니의 고유 식별자")
                     ),
                     responseFields(
-                        fieldWithPath("item")
-                            .type(JsonFieldType.OBJECT)
-                            .description("조회 데이터"),
-                        fieldWithPath("item.anime")
+                        fieldWithPath("anime")
                             .type(JsonFieldType.OBJECT)
                             .description("애니 정보"),
-                        fieldWithPath("item.anime.animeId")
+                        fieldWithPath("anime.id")
                             .type(JsonFieldType.NUMBER)
                             .description("애니의 고유 식별자"),
-                        fieldWithPath("item.anime.title")
+                        fieldWithPath("anime.title")
                             .type(JsonFieldType.STRING)
                             .description("애니 제목"),
-                        fieldWithPath("item.anime.thumbnail")
+                        fieldWithPath("anime.thumbnail")
                             .type(JsonFieldType.STRING)
                             .description("애니 이미지, 경로로 저장됨"),
-                        fieldWithPath("item.anime.broadcast")
-                            .type(JsonFieldType.OBJECT)
-                            .description("애니 방송 관련 정보"),
-                        fieldWithPath("item.anime.broadcast.broadcastType")
+                        fieldWithPath("anime.broadcastType")
                             .type(JsonFieldType.STRING)
                             .description("작품의 출시 방식. TVA, OVA, ONA, MOV가 있음"),
-                        fieldWithPath("item.anime.broadcast.year")
+                        fieldWithPath("anime.year")
                             .type(JsonFieldType.NUMBER)
                             .description("작품의 출시 년도"),
-                        fieldWithPath("item.anime.broadcast.quarter")
+                        fieldWithPath("anime.quarter")
                             .type(JsonFieldType.STRING)
                             .description("작품의 출시 분기"),
-                        fieldWithPath("item.anime.summary")
+                        fieldWithPath("anime.summary")
                             .type(JsonFieldType.STRING)
                             .description("애니를 소개할 때 줄거리"),
-                        fieldWithPath("item.anime.episodeCount")
+                        fieldWithPath("anime.episodeCount")
                             .type(JsonFieldType.NUMBER)
                             .description("에피소드의 숫자. 16화까지 나왔으면 16으로 표기됨."),
-                        fieldWithPath("item.anime.rating")
+                        fieldWithPath("anime.rating")
                             .type(JsonFieldType.STRING)
                             .description("작품의 심의 등급. ADULT, FIFTEEN, TWELVE, ALL가 있다."),
-                        fieldWithPath("item.anime.status")
+                        fieldWithPath("anime.status")
                             .type(JsonFieldType.STRING)
                             .description("방영 상태. FINISHED, ONGOING, UPCOMING, UNKNOWN이 있다."),
-                        fieldWithPath("item.anime.genres")
+                        fieldWithPath("anime.genres")
                             .type(JsonFieldType.ARRAY)
                             .description("애니의 장르."),
-                        fieldWithPath("item.anime.originalAuthors")
+                        fieldWithPath("anime.originalAuthors")
                             .type(JsonFieldType.ARRAY)
                             .description("애니의 원작 작가."),
-                        fieldWithPath("item.anime.voiceActors")
+                        fieldWithPath("anime.voiceActors")
                             .type(JsonFieldType.ARRAY)
                             .description("애니의 출연 성우."),
-                        fieldWithPath("item.anime.studios")
+                        fieldWithPath("anime.studios")
                             .type(JsonFieldType.ARRAY)
                             .description("애니의 제작사."),
-                        fieldWithPath("item.anime.reviewCount")
+                        fieldWithPath("anime.reviewCount")
                             .type(JsonFieldType.NUMBER)
                             .description("애니의 리뷰 개수."),
-                        fieldWithPath("item.anime.bookmarkCount")
+                        fieldWithPath("anime.bookmarkCount")
                             .type(JsonFieldType.NUMBER)
                             .description("애니의 덕후 수.")
                     )

--- a/src/test/java/io/oduck/api/global/utils/AnimeTestUtils.java
+++ b/src/test/java/io/oduck/api/global/utils/AnimeTestUtils.java
@@ -1,0 +1,92 @@
+package io.oduck.api.global.utils;
+
+import io.oduck.api.domain.anime.dto.AnimeReq.PatchAnimeReq;
+import io.oduck.api.domain.anime.dto.AnimeReq.PostReq;
+import io.oduck.api.domain.anime.entity.BroadcastType;
+import io.oduck.api.domain.anime.entity.Quarter;
+import io.oduck.api.domain.anime.entity.Rating;
+import io.oduck.api.domain.anime.entity.Status;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AnimeTestUtils {
+    public static PostReq createPostAnimeRequest(){
+        return new PostReq(
+            getTitle(), getSummary(), getBroadcastType(), getEpisodeCount(),
+            getThumbnail(), getYear(), getQuarter(), getRating(), getStatus(),
+            getOriginalAuthorIds(), getStudioIds(), getVoiceActorIds(), getGenreIds(), getSeriesId());
+    }
+
+    public static PatchAnimeReq createPatchAnimeRequest(){
+        return new PatchAnimeReq(
+            getTitle(), getSummary(), getBroadcastType(), getEpisodeCount(),
+            getThumbnail(), getYear(), getQuarter(), getRating(), getStatus());
+    }
+
+    public static long getSeriesId() {
+        return 1L;
+    }
+
+    public static Status getStatus() {
+        return Status.FINISHED;
+    }
+
+    public static Rating getRating() {
+        return Rating.ADULT;
+    }
+
+    public static Quarter getQuarter() {
+        return Quarter.Q2;
+    }
+
+    public static int getYear() {
+        return 2023;
+    }
+
+    public static String getThumbnail() {
+        return "/uuid.jpg";
+    }
+
+    public static int getEpisodeCount() {
+        return 11;
+    }
+
+    public static BroadcastType getBroadcastType() {
+        return BroadcastType.TVA;
+    }
+
+    public static String getSummary() {
+        return "113년 만에 상현 혈귀가 죽자 분개한 무잔은 나머지 상현 혈귀들에게 또 다른 명령을 내린다! 한편, 규타로와의 전투 도중 검이 심하게 손상된 탄지로에게 하가네즈카는 대 격노하고 탄지로는 그 검을 만든 대장장이 하가네즈카 호타루에게 검이 어떻게 심하게 손상되었는지 설명하기 위해 도공 마을을 방문한다.";
+    }
+
+    public static String getTitle() {
+        return "귀멸의 칼날: 도공 마을편";
+    }
+
+
+    public static List getGenreIds() {
+        List genreIds = new ArrayList();
+        genreIds.add(4L);
+        genreIds.add(5L);
+        return genreIds;
+    }
+
+    public static List getVoiceActorIds() {
+        List voiceActorIds = getStudioIds();
+        voiceActorIds.add(2L);
+        voiceActorIds.add(4L);
+        return voiceActorIds;
+    }
+
+    public static List getStudioIds() {
+        List studioIds = new ArrayList();
+        studioIds.add(1L);
+        return studioIds;
+    }
+
+    public static List getOriginalAuthorIds() {
+        List originalAuthorIds = new ArrayList();
+        originalAuthorIds.add(5L);
+        return originalAuthorIds;
+    }
+}

--- a/src/test/java/io/oduck/api/unit/anime/service/AnimeServiceTest.java
+++ b/src/test/java/io/oduck/api/unit/anime/service/AnimeServiceTest.java
@@ -3,8 +3,10 @@ package io.oduck.api.unit.anime.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
+import io.oduck.api.domain.anime.dto.AnimeReq.PostReq;
 import io.oduck.api.domain.anime.dto.AnimeRes;
 import io.oduck.api.domain.anime.service.AnimeServiceStub;
+import io.oduck.api.global.utils.AnimeTestUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -34,6 +36,21 @@ public class AnimeServiceTest {
             //then
             assertThat(response.getAnime().getId()).isEqualTo(animeId);
             assertThatNoException();
+        }
+    }
+
+    @Nested
+    @DisplayName("애니 등록")
+    class PostAnime{
+
+        @Test
+        @DisplayName("애니 등록 성공")
+        void postAnime(){
+            PostReq req = AnimeTestUtils.createPostAnimeRequest();
+
+            Long animeId = animeService.save(req);
+
+            assertThat(animeId).isEqualTo(1L);
         }
     }
 }

--- a/src/test/java/io/oduck/api/unit/anime/service/AnimeServiceTest.java
+++ b/src/test/java/io/oduck/api/unit/anime/service/AnimeServiceTest.java
@@ -32,7 +32,7 @@ public class AnimeServiceTest {
             AnimeRes response = animeService.getAnimeById(animeId);
 
             //then
-            assertThat(response.getAnime().getAnimeId()).isEqualTo(animeId);
+            assertThat(response.getAnime().getId()).isEqualTo(animeId);
             assertThatNoException();
         }
     }


### PR DESCRIPTION
## 📝 개요
docs 일부 수정, 애니 추가, 수정 api 문서화

## 🚀 변경사항
1. 단일 객체 응답 시 바로 응답하도록 변경
2. 1에 따른 문서화 수정
3. 애니 추가, 수정 api 문서화
4. 어드민 도메인 추가

## 🔗 관련 이슈
#17 

## ➕ 기타

![제목 없음](https://github.com/oduck-team/oduck-server/assets/113520315/d66f1268-8af9-4ace-8d43-a33cc22a7a63)
어제 수정 사항 커밋들 `feature/17` 브랜치에 push했습니다. `index.adoc` 파일만 push하고 있지 않았는데, 하니님 마지된 거 확인 이후 `develope` 브랜치 pull 한 다음에 adoc 파일을 push했는데 문제 있을까요?😱