### PR TITLE
애니 도메인 구현 #28

### DIFF
--- a/src/main/java/io/oduck/api/domain/anime/entity/Anime.java
+++ b/src/main/java/io/oduck/api/domain/anime/entity/Anime.java
@@ -189,7 +189,7 @@ public class Anime extends BaseEntity {
     return !elements.isEmpty();
   }
 
-  public void assignAnimeOriginalAuthors(List<AnimeOriginalAuthor> animeOriginalAuthors){
+  public void updateAnimeOriginalAuthors(List<AnimeOriginalAuthor> animeOriginalAuthors){
     // 만약 현재 animeOriginalAuthors에 값이 존재한다면 List를 비운다.
     // (orphanRemoval = true 설정으로 AnimeOriginalAuthor 테이블의 값들이 delete됨)
     if(isEntityListElementsExist(this.animeOriginalAuthors)){
@@ -201,7 +201,7 @@ public class Anime extends BaseEntity {
     }
   }
 
-  public void assignAnimeStudios(List<AnimeStudio> animeStudios) {
+  public void updateAnimeStudios(List<AnimeStudio> animeStudios) {
     // 만약 현재 animeStudios에 값이 존재한다면 List를 비운다.
     // (orphanRemoval = true 설정으로 AnimeStudio 테이블의 값들이 delete됨)
     if(isEntityListElementsExist(this.animeStudios)){
@@ -213,7 +213,7 @@ public class Anime extends BaseEntity {
     }
   }
 
-  public void assignAnimeVoiceActors(List<AnimeVoiceActor> animeVoiceActors) {
+  public void updateAnimeVoiceActors(List<AnimeVoiceActor> animeVoiceActors) {
     // 만약 현재 animeVoiceActors의 값이 존재한다면 List를 비운다.
     // (orphanRemoval = true 설정으로 animeVoiceActor 테이블의 값들이 delete됨)
     if(isEntityListElementsExist(this.animeVoiceActors)){
@@ -225,7 +225,7 @@ public class Anime extends BaseEntity {
     }
   }
 
-  public void assignAnimeGenre(List<AnimeGenre> animeGenres) {
+  public void updateAnimeGenre(List<AnimeGenre> animeGenres) {
     // 만약 현재 animeGenre의 값이 존재한다면 List를 비운다.
     // (orphanRemoval = true 설정으로 animeGenre의 테이블의 값들이 delete됨)
     if(isEntityListElementsExist(this.animeGenres)){
@@ -259,10 +259,10 @@ public class Anime extends BaseEntity {
     anime.starRatingCount = 0;
     
     // 연결 엔티티 설정
-    anime.assignAnimeOriginalAuthors(animeOriginalAuthors);
-    anime.assignAnimeStudios(animeStudios);
-    anime.assignAnimeVoiceActors(animeVoiceActors);
-    anime.assignAnimeGenre(animeGenres);
+    anime.updateAnimeOriginalAuthors(animeOriginalAuthors);
+    anime.updateAnimeStudios(animeStudios);
+    anime.updateAnimeVoiceActors(animeVoiceActors);
+    anime.updateAnimeGenre(animeGenres);
     
     // 시리즈 설정
     anime.series = series;

--- a/src/main/java/io/oduck/api/domain/anime/entity/Anime.java
+++ b/src/main/java/io/oduck/api/domain/anime/entity/Anime.java
@@ -95,11 +95,6 @@ public class Anime extends BaseEntity {
     viewCount++;
   }
 
-  // 조회수 감소
-  public void decreaseViewCount(){
-    viewCount--;
-  }
-
   // 리뷰수 증가(짧은 리뷰, 장문 리뷰)
   public void increaseReviewCount(){
     reviewCount++;

--- a/src/main/java/io/oduck/api/domain/anime/entity/Anime.java
+++ b/src/main/java/io/oduck/api/domain/anime/entity/Anime.java
@@ -237,6 +237,23 @@ public class Anime extends BaseEntity {
     }
   }
 
+  public void update(String title, String summary, BroadcastType broadcastType, int episodeCount,
+      String thumbnail, int year, Quarter quarter, Rating rating, Status status){
+    this.title = title;
+    this.summary = summary;
+    this.broadcastType = broadcastType;
+    this.episodeCount = episodeCount;
+    this.thumbnail = thumbnail;
+    this.year = year;
+    this.quarter = quarter;
+    this.rating = rating;
+    this.status = status;
+  }
+
+  public void update(Series series){
+    this.series = series;
+  }
+
   public static Anime createAnime(String title, String summary, BroadcastType broadcastType, int episodeCount,
       String thumbnail, int year, Quarter quarter, Rating rating, Status status,
       List<AnimeOriginalAuthor> animeOriginalAuthors, List<AnimeStudio> animeStudios, List<AnimeVoiceActor> animeVoiceActors, List<AnimeGenre> animeGenres, Series series) {

--- a/src/main/java/io/oduck/api/domain/anime/entity/Anime.java
+++ b/src/main/java/io/oduck/api/domain/anime/entity/Anime.java
@@ -71,6 +71,9 @@ public class Anime extends BaseEntity {
   @ColumnDefault("0")
   private long starRatingScoreTotal;
 
+  @ColumnDefault("0")
+  private long starRatingCount;
+
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "series_id")
   private Series series;
@@ -242,6 +245,8 @@ public class Anime extends BaseEntity {
     anime.viewCount = 0;
     anime.reviewCount = 0;
     anime.bookmarkCount = 0;
+    anime.starRatingScoreTotal = 0;
+    anime.starRatingCount = 0;
     
     // 연결 엔티티 설정
     anime.assignAnimeOriginalAuthors(animeOriginalAuthors);

--- a/src/main/java/io/oduck/api/domain/anime/entity/Anime.java
+++ b/src/main/java/io/oduck/api/domain/anime/entity/Anime.java
@@ -14,18 +14,15 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter
-@Builder
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class Anime extends BaseEntity {
 
   @Id
@@ -71,19 +68,136 @@ public class Anime extends BaseEntity {
   @ColumnDefault("0")
   private long bookmarkCount;
 
+  @ColumnDefault("0")
+  private long starRatingScoreTotal;
+
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "series_id")
   private Series series;
 
-  @OneToMany(mappedBy = "anime", cascade = CascadeType.PERSIST)
-  private List<AnimeOriginalAuthor> animeOriginalAuthors;
+  @OneToMany(mappedBy = "anime", cascade = CascadeType.PERSIST, orphanRemoval = true)
+  private List<AnimeOriginalAuthor> animeOriginalAuthors = new ArrayList<>();
 
-  @OneToMany(mappedBy = "anime", cascade = CascadeType.PERSIST)
-  private List<AnimeStudio> animeStudios;
+  @OneToMany(mappedBy = "anime", cascade = CascadeType.PERSIST, orphanRemoval = true)
+  private List<AnimeStudio> animeStudios = new ArrayList<>();
 
-  @OneToMany(mappedBy = "anime", cascade = CascadeType.PERSIST)
-  private List<AnimeVoiceActor> animeVoiceActors;
+  @OneToMany(mappedBy = "anime", cascade = CascadeType.PERSIST, orphanRemoval = true)
+  private List<AnimeVoiceActor> animeVoiceActors = new ArrayList<>();
 
-  @OneToMany(mappedBy = "anime", cascade = CascadeType.PERSIST)
-  private List<AnimeGenre> animeGenres;
+  @OneToMany(mappedBy = "anime", cascade = CascadeType.PERSIST, orphanRemoval = true)
+  private List<AnimeGenre> animeGenres = new ArrayList<>();
+
+  /**
+   * 연관 관계 관련한 메소드
+   */
+  // 애니와 원작 작가의 연결 엔티티의 애니 연관 관계 추가 로직
+  private void addAnimeOriginalAuthor(AnimeOriginalAuthor animeOriginalAuthor){
+    this.animeOriginalAuthors.add(animeOriginalAuthor);
+    //TODO: set 대신 다른 이름
+    animeOriginalAuthor.setAnime(this);
+  }
+
+  // 애니와 스튜디오의 연결 엔티티의 애니 연관 관계 추가 로직
+  private void addAnimeStudio(AnimeStudio animeStudio){
+    this.animeStudios.add(animeStudio);
+    //TODO: set 대신 다른 이름
+    animeStudio.setAnime(this);
+  }
+
+  // 애니와 성우의 연결 엔티티의 애니 연관 관계 추가 로직
+  private void addAnimeVoiceActor(AnimeVoiceActor animeVoiceActor){
+    this.animeVoiceActors.add(animeVoiceActor);
+    //TODO: set 대신 다른 이름
+    animeVoiceActor.setAnime(this);
+  }
+
+  // 애니와 장르의 연결 엔티티의 애니 연관 관계 추가 로직
+  private void addAnimeGenre(AnimeGenre animeGenre){
+    this.animeGenres.add(animeGenre);
+    //TODO: set 대신 다른 이름
+    animeGenre.setAnime(this);
+  }
+
+  private boolean isEntityListElementsExist(List<? extends BaseEntity> elements) {
+    return !elements.isEmpty();
+  }
+
+  public void assignAnimeOriginalAuthors(List<AnimeOriginalAuthor> animeOriginalAuthors){
+    // 만약 현재 animeOriginalAuthors에 값이 존재한다면 List를 비운다.
+    // (orphanRemoval = true 설정으로 AnimeOriginalAuthor 테이블의 값들이 delete됨)
+    if(isEntityListElementsExist(this.animeOriginalAuthors)){
+      this.animeOriginalAuthors.clear();
+    }
+
+    for (AnimeOriginalAuthor animeOriginalAuthor : animeOriginalAuthors) {
+      addAnimeOriginalAuthor(animeOriginalAuthor);
+    }
+  }
+
+  public void assignAnimeStudios(List<AnimeStudio> animeStudios) {
+    // 만약 현재 animeStudios에 값이 존재한다면 List를 비운다.
+    // (orphanRemoval = true 설정으로 AnimeStudio 테이블의 값들이 delete됨)
+    if(isEntityListElementsExist(this.animeStudios)){
+      this.animeStudios.clear();
+    }
+
+    for (AnimeStudio animeStudio : animeStudios) {
+      addAnimeStudio(animeStudio);
+    }
+  }
+
+  public void assignAnimeVoiceActors(List<AnimeVoiceActor> animeVoiceActors) {
+    // 만약 현재 animeVoiceActors의 값이 존재한다면 List를 비운다.
+    // (orphanRemoval = true 설정으로 animeVoiceActor 테이블의 값들이 delete됨)
+    if(isEntityListElementsExist(this.animeVoiceActors)){
+      this.animeVoiceActors.clear();
+    }
+
+    for (AnimeVoiceActor animeVoiceActor : animeVoiceActors) {
+      addAnimeVoiceActor(animeVoiceActor);
+    }
+  }
+
+  public void assignAnimeGenre(List<AnimeGenre> animeGenres) {
+    // 만약 현재 animeGenre의 값이 존재한다면 List를 비운다.
+    // (orphanRemoval = true 설정으로 animeGenre의 테이블의 값들이 delete됨)
+    if(isEntityListElementsExist(this.animeGenres)){
+      this.animeGenres.clear();
+    }
+
+    for (AnimeGenre animeGenre : animeGenres) {
+      addAnimeGenre(animeGenre);
+    }
+  }
+
+
+  public static Anime createAnime(String title, String summary, BroadcastType broadcastType, int episodeCount,
+      String thumbnail, int year, Quarter quarter, Rating rating, Status status,
+      List<AnimeOriginalAuthor> animeOriginalAuthors, List<AnimeStudio> animeStudios, List<AnimeVoiceActor> animeVoiceActors, List<AnimeGenre> animeGenres, Series series) {
+    Anime anime = new Anime();
+    // dto의 값으로 anime 초기화
+    anime.title = title;
+    anime.summary = summary;
+    anime.broadcastType = broadcastType;
+    anime.episodeCount = episodeCount;
+    anime.thumbnail = thumbnail;
+    anime.year = year;
+    anime.quarter = quarter;
+    anime.rating = rating;
+    anime.status = status;
+    anime.isReleased = false;
+    anime.viewCount = 0;
+    anime.reviewCount = 0;
+    anime.bookmarkCount = 0;
+    
+    // 연결 엔티티 설정
+    anime.assignAnimeOriginalAuthors(animeOriginalAuthors);
+    anime.assignAnimeStudios(animeStudios);
+    anime.assignAnimeVoiceActors(animeVoiceActors);
+    anime.assignAnimeGenre(animeGenres);
+    
+    // 시리즈 설정
+    anime.series = series;
+    return anime;
+  }
 }

--- a/src/main/java/io/oduck/api/domain/anime/entity/Anime.java
+++ b/src/main/java/io/oduck/api/domain/anime/entity/Anime.java
@@ -134,6 +134,7 @@ public class Anime extends BaseEntity {
       throw new IllegalArgumentException("음수는 올 수 없습니다.");
     }
     starRatingScoreTotal += score;
+    increaseStarRatingCount();
   }
 
   // 평가를 지웠을 때 점수 합산(별점)
@@ -142,6 +143,15 @@ public class Anime extends BaseEntity {
       throw new IllegalArgumentException("음수는 올 수 없습니다.");
     }
     starRatingScoreTotal -= score;
+    decreaseStarRatingCount();
+  }
+
+  private void increaseStarRatingCount() {
+    starRatingCount++;
+  }
+
+  private void decreaseStarRatingCount() {
+    starRatingCount--;
   }
 
   /**

--- a/src/main/java/io/oduck/api/domain/anime/entity/Anime.java
+++ b/src/main/java/io/oduck/api/domain/anime/entity/Anime.java
@@ -88,6 +88,65 @@ public class Anime extends BaseEntity {
   private List<AnimeGenre> animeGenres = new ArrayList<>();
 
   /**
+   * 비즈니스 메소드
+   */
+  // 조회수 증가
+  public void increaseViewCount(){
+    viewCount++;
+  }
+
+  // 조회수 감소
+  public void decreaseViewCount(){
+    viewCount--;
+  }
+
+  // 리뷰수 증가(짧은 리뷰, 장문 리뷰)
+  public void increaseReviewCount(){
+    reviewCount++;
+  }
+
+  // 리뷰수 감소(짧은 리뷰, 장문 리뷰)
+  public void decreaseReviewCount(){
+    reviewCount--;
+  }
+
+  // 북마크수 증가
+  public void increaseBookmarkCount(){
+    bookmarkCount++;
+  }
+
+  // 북마크수 감소
+  public void decreaseBookmarkCount(){
+    bookmarkCount--;
+  }
+
+  // 애니 공개 전환
+  public void releaseAnime(){
+    isReleased = true;
+  }
+
+  // 비공개 전환
+  public void setPrivateAnime(){
+    isReleased = false;
+  }
+
+  // 평가할 때 점수 합산(별점)
+  public void increaseStarRatingScore(int score){
+    if(score <= 0){
+      throw new IllegalArgumentException("음수는 올 수 없습니다.");
+    }
+    starRatingScoreTotal += score;
+  }
+
+  // 평가를 지웠을 때 점수 합산(별점)
+  public void decreaseStarRatingScore(int score){
+    if(score <= 0){
+      throw new IllegalArgumentException("음수는 올 수 없습니다.");
+    }
+    starRatingScoreTotal -= score;
+  }
+
+  /**
    * 연관 관계 관련한 메소드
    */
   // 애니와 원작 작가의 연결 엔티티의 애니 연관 관계 추가 로직
@@ -169,7 +228,6 @@ public class Anime extends BaseEntity {
       addAnimeGenre(animeGenre);
     }
   }
-
 
   public static Anime createAnime(String title, String summary, BroadcastType broadcastType, int episodeCount,
       String thumbnail, int year, Quarter quarter, Rating rating, Status status,

--- a/src/main/java/io/oduck/api/domain/anime/entity/AnimeGenre.java
+++ b/src/main/java/io/oduck/api/domain/anime/entity/AnimeGenre.java
@@ -1,6 +1,7 @@
 package io.oduck.api.domain.anime.entity;
 
 import io.oduck.api.domain.genre.entity.Genre;
+import io.oduck.api.global.audit.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -15,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class AnimeGenre {
+public class AnimeGenre extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/io/oduck/api/domain/anime/entity/AnimeGenre.java
+++ b/src/main/java/io/oduck/api/domain/anime/entity/AnimeGenre.java
@@ -8,12 +8,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AnimeGenre {
 
   @Id
@@ -27,4 +28,18 @@ public class AnimeGenre {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "genre_id")
   private Genre genre;
+
+  public void setAnime(Anime anime) {
+    this.anime = anime;
+  }
+
+  /**
+   * M:N 관계 연결 테이블(연결 엔티티) 생성 시 빌더를 사용하면 애니의 연관 관계도 생성할 때 추가할 수 있어
+   * 생성 메소드로 구현
+   */
+  public static AnimeGenre createAnimeGenre(Genre genre) {
+    AnimeGenre animeGenre = new AnimeGenre();
+    animeGenre.genre = genre;
+    return animeGenre;
+  }
 }

--- a/src/main/java/io/oduck/api/domain/anime/entity/AnimeOriginalAuthor.java
+++ b/src/main/java/io/oduck/api/domain/anime/entity/AnimeOriginalAuthor.java
@@ -1,8 +1,5 @@
 package io.oduck.api.domain.anime.entity;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
 import io.oduck.api.domain.originalAuthor.entity.OriginalAuthor;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -11,10 +8,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AnimeOriginalAuthor {
 
   @Id
@@ -28,4 +28,18 @@ public class AnimeOriginalAuthor {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "original_author_id")
   private OriginalAuthor originalAuthor;
+
+  public void setAnime(Anime anime) {
+    this.anime = anime;
+  }
+
+  /**
+   * M:N 관계 연결 테이블(연결 엔티티) 생성 시 빌더를 사용하면 애니의 연관 관계도 생성할 때 추가할 수 있어
+   * 생성 메소드로 구현
+   */
+  public static AnimeOriginalAuthor createAnimeOriginalAuthor(OriginalAuthor originalAuthor){
+    AnimeOriginalAuthor animeOriginalAuthor = new AnimeOriginalAuthor();
+    animeOriginalAuthor.originalAuthor = originalAuthor;
+    return animeOriginalAuthor;
+  }
 }

--- a/src/main/java/io/oduck/api/domain/anime/entity/AnimeOriginalAuthor.java
+++ b/src/main/java/io/oduck/api/domain/anime/entity/AnimeOriginalAuthor.java
@@ -1,6 +1,7 @@
 package io.oduck.api.domain.anime.entity;
 
 import io.oduck.api.domain.originalAuthor.entity.OriginalAuthor;
+import io.oduck.api.global.audit.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -15,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class AnimeOriginalAuthor {
+public class AnimeOriginalAuthor extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/io/oduck/api/domain/anime/entity/AnimeStudio.java
+++ b/src/main/java/io/oduck/api/domain/anime/entity/AnimeStudio.java
@@ -1,6 +1,7 @@
 package io.oduck.api.domain.anime.entity;
 
 import io.oduck.api.domain.studio.entity.Studio;
+import io.oduck.api.global.audit.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -15,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class AnimeStudio {
+public class AnimeStudio extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/io/oduck/api/domain/anime/entity/AnimeStudio.java
+++ b/src/main/java/io/oduck/api/domain/anime/entity/AnimeStudio.java
@@ -1,7 +1,5 @@
 package io.oduck.api.domain.anime.entity;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import io.oduck.api.domain.studio.entity.Studio;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -10,10 +8,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AnimeStudio {
 
   @Id
@@ -27,4 +28,18 @@ public class AnimeStudio {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "studio_id")
   private Studio studio;
+
+  public void setAnime(Anime anime) {
+    this.anime = anime;
+  }
+
+  /**
+   * M:N 관계 연결 테이블(연결 엔티티) 생성 시 빌더를 사용하면 애니의 연관 관계도 생성할 때 추가할 수 있어
+   * 생성 메소드로 구현
+   */
+  public static AnimeStudio createAnimeStudio(Studio studio) {
+    AnimeStudio animeStudio = new AnimeStudio();
+    animeStudio.studio = studio;
+    return animeStudio;
+  }
 }

--- a/src/main/java/io/oduck/api/domain/anime/entity/AnimeVoiceActor.java
+++ b/src/main/java/io/oduck/api/domain/anime/entity/AnimeVoiceActor.java
@@ -1,9 +1,7 @@
 package io.oduck.api.domain.anime.entity;
 
-import jakarta.persistence.Column;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import io.oduck.api.domain.voiceActor.entity.VoiceActor;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -11,10 +9,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AnimeVoiceActor {
 
   @Id
@@ -31,4 +32,19 @@ public class AnimeVoiceActor {
 
   @Column(nullable = false, length = 100)
   private String part;
+
+  public void setAnime(Anime anime) {
+    this.anime = anime;
+  }
+
+  /**
+   * M:N 관계 연결 테이블(연결 엔티티) 생성 시 빌더를 사용하면 애니의 연관 관계도 생성할 때 추가할 수 있어
+   * 생성 메소드로 구현
+   */
+  public static AnimeVoiceActor createAnimeVoiceActor(String part, VoiceActor voiceActor) {
+    AnimeVoiceActor animeVoiceActor = new AnimeVoiceActor();
+    animeVoiceActor.part = part;
+    animeVoiceActor.voiceActor = voiceActor;
+    return animeVoiceActor;
+  }
 }

--- a/src/main/java/io/oduck/api/domain/anime/entity/AnimeVoiceActor.java
+++ b/src/main/java/io/oduck/api/domain/anime/entity/AnimeVoiceActor.java
@@ -1,6 +1,7 @@
 package io.oduck.api.domain.anime.entity;
 
 import io.oduck.api.domain.voiceActor.entity.VoiceActor;
+import io.oduck.api.global.audit.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -16,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class AnimeVoiceActor {
+public class AnimeVoiceActor extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/io/oduck/api/domain/anime/repository/AnimeGenreRepository.java
+++ b/src/main/java/io/oduck/api/domain/anime/repository/AnimeGenreRepository.java
@@ -1,8 +1,16 @@
 package io.oduck.api.domain.anime.repository;
 
 import io.oduck.api.domain.anime.entity.AnimeGenre;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AnimeGenreRepository extends JpaRepository<AnimeGenre, Long> {
 
+    @Query("select ag from AnimeGenre ag "
+        + "join ag.anime "
+        + "join ag.genre "
+        + "where ag.anime.id = :animeId")
+    List<AnimeGenre> findAllByAnimeId(@Param("animeId") Long animeId);
 }

--- a/src/main/java/io/oduck/api/domain/anime/repository/AnimeGenreRepository.java
+++ b/src/main/java/io/oduck/api/domain/anime/repository/AnimeGenreRepository.java
@@ -1,0 +1,8 @@
+package io.oduck.api.domain.anime.repository;
+
+import io.oduck.api.domain.anime.entity.AnimeGenre;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnimeGenreRepository extends JpaRepository<AnimeGenre, Long> {
+
+}

--- a/src/main/java/io/oduck/api/domain/anime/repository/AnimeOriginalAuthorRepository.java
+++ b/src/main/java/io/oduck/api/domain/anime/repository/AnimeOriginalAuthorRepository.java
@@ -1,8 +1,16 @@
 package io.oduck.api.domain.anime.repository;
 
 import io.oduck.api.domain.anime.entity.AnimeOriginalAuthor;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AnimeOriginalAuthorRepository extends JpaRepository<AnimeOriginalAuthor, Long> {
 
+    @Query("select aoa from AnimeOriginalAuthor aoa "
+        + "join fetch aoa.anime "
+        + "join fetch aoa.originalAuthor "
+        + "where aoa.anime.id = :animeId")
+    List<AnimeOriginalAuthor> findAllByAnimeId(@Param("animeId") Long animeId);
 }

--- a/src/main/java/io/oduck/api/domain/anime/repository/AnimeOriginalAuthorRepository.java
+++ b/src/main/java/io/oduck/api/domain/anime/repository/AnimeOriginalAuthorRepository.java
@@ -1,0 +1,8 @@
+package io.oduck.api.domain.anime.repository;
+
+import io.oduck.api.domain.anime.entity.AnimeOriginalAuthor;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnimeOriginalAuthorRepository extends JpaRepository<AnimeOriginalAuthor, Long> {
+
+}

--- a/src/main/java/io/oduck/api/domain/anime/repository/AnimeStudioRepository.java
+++ b/src/main/java/io/oduck/api/domain/anime/repository/AnimeStudioRepository.java
@@ -1,8 +1,16 @@
 package io.oduck.api.domain.anime.repository;
 
 import io.oduck.api.domain.anime.entity.AnimeStudio;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AnimeStudioRepository extends JpaRepository<AnimeStudio, Long> {
 
+    @Query("select ast from AnimeStudio ast "
+        + "join ast.anime "
+        + "join ast.studio "
+        + "where ast.anime.id = :animeId")
+    List<AnimeStudio> findAllByAnimeId(@Param("animeId") Long animeId);
 }

--- a/src/main/java/io/oduck/api/domain/anime/repository/AnimeStudioRepository.java
+++ b/src/main/java/io/oduck/api/domain/anime/repository/AnimeStudioRepository.java
@@ -1,0 +1,8 @@
+package io.oduck.api.domain.anime.repository;
+
+import io.oduck.api.domain.anime.entity.AnimeStudio;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnimeStudioRepository extends JpaRepository<AnimeStudio, Long> {
+
+}

--- a/src/main/java/io/oduck/api/domain/anime/repository/AnimeVoiceActorRepository.java
+++ b/src/main/java/io/oduck/api/domain/anime/repository/AnimeVoiceActorRepository.java
@@ -1,0 +1,8 @@
+package io.oduck.api.domain.anime.repository;
+
+import io.oduck.api.domain.anime.entity.AnimeVoiceActor;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnimeVoiceActorRepository extends JpaRepository<AnimeVoiceActor, Long> {
+
+}

--- a/src/main/java/io/oduck/api/domain/anime/repository/AnimeVoiceActorRepository.java
+++ b/src/main/java/io/oduck/api/domain/anime/repository/AnimeVoiceActorRepository.java
@@ -1,8 +1,16 @@
 package io.oduck.api.domain.anime.repository;
 
 import io.oduck.api.domain.anime.entity.AnimeVoiceActor;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AnimeVoiceActorRepository extends JpaRepository<AnimeVoiceActor, Long> {
 
+    @Query("select ava from AnimeVoiceActor ava "
+        + "join ava.anime "
+        + "join ava.voiceActor "
+        + "where ava.anime.id = :animeId")
+    List<AnimeVoiceActor> findAllByAnimeId(@Param("animeId") Long animeId);
 }

--- a/src/main/java/io/oduck/api/domain/genre/entity/Genre.java
+++ b/src/main/java/io/oduck/api/domain/genre/entity/Genre.java
@@ -1,21 +1,21 @@
 package io.oduck.api.domain.genre.entity;
 
-import io.oduck.api.domain.anime.entity.AnimeGenre;
 import io.oduck.api.global.audit.BaseEntity;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class Genre extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,7 +23,4 @@ public class Genre extends BaseEntity {
 
   @Column(nullable = false, length = 15)
   private String name;
-
-  @OneToMany(mappedBy = "genre", cascade = CascadeType.PERSIST)
-  private List<AnimeGenre> animeGenres;
 }

--- a/src/main/java/io/oduck/api/domain/genre/repository/GenreRepository.java
+++ b/src/main/java/io/oduck/api/domain/genre/repository/GenreRepository.java
@@ -1,0 +1,8 @@
+package io.oduck.api.domain.genre.repository;
+
+import io.oduck.api.domain.genre.entity.Genre;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GenreRepository extends JpaRepository<Genre, Long> {
+
+}

--- a/src/main/java/io/oduck/api/domain/originalAuthor/entity/OriginalAuthor.java
+++ b/src/main/java/io/oduck/api/domain/originalAuthor/entity/OriginalAuthor.java
@@ -1,21 +1,21 @@
 package io.oduck.api.domain.originalAuthor.entity;
 
-import io.oduck.api.domain.anime.entity.AnimeOriginalAuthor;
 import io.oduck.api.global.audit.BaseEntity;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class OriginalAuthor extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,7 +23,4 @@ public class OriginalAuthor extends BaseEntity {
 
   @Column(nullable = false, length = 50)
   private String name;
-
-  @OneToMany(mappedBy = "originalAuthor", cascade = CascadeType.PERSIST)
-  private List<AnimeOriginalAuthor> animeOriginalAuthors;
 }

--- a/src/main/java/io/oduck/api/domain/originalAuthor/repository/OriginalAuthorRepository.java
+++ b/src/main/java/io/oduck/api/domain/originalAuthor/repository/OriginalAuthorRepository.java
@@ -1,0 +1,8 @@
+package io.oduck.api.domain.originalAuthor.repository;
+
+import io.oduck.api.domain.originalAuthor.entity.OriginalAuthor;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OriginalAuthorRepository extends JpaRepository<OriginalAuthor, Long> {
+
+}

--- a/src/main/java/io/oduck/api/domain/series/entity/Series.java
+++ b/src/main/java/io/oduck/api/domain/series/entity/Series.java
@@ -1,22 +1,21 @@
 package io.oduck.api.domain.series.entity;
 
-import io.oduck.api.domain.anime.entity.Anime;
 import io.oduck.api.global.audit.BaseEntity;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import java.util.List;
-
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class Series extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,7 +23,4 @@ public class Series extends BaseEntity {
 
   @Column(nullable = false, length = 50)
   private String title;
-
-  @OneToMany(mappedBy = "series", cascade = CascadeType.PERSIST)
-  private List<Anime> animes;
 }

--- a/src/main/java/io/oduck/api/domain/series/repository/SeriesRepository.java
+++ b/src/main/java/io/oduck/api/domain/series/repository/SeriesRepository.java
@@ -1,0 +1,8 @@
+package io.oduck.api.domain.series.repository;
+
+import io.oduck.api.domain.series.entity.Series;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SeriesRepository extends JpaRepository<Series, Long> {
+
+}

--- a/src/main/java/io/oduck/api/domain/studio/entity/Studio.java
+++ b/src/main/java/io/oduck/api/domain/studio/entity/Studio.java
@@ -1,21 +1,21 @@
 package io.oduck.api.domain.studio.entity;
 
-import io.oduck.api.domain.anime.entity.AnimeStudio;
 import io.oduck.api.global.audit.BaseEntity;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class Studio extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,7 +23,4 @@ public class Studio extends BaseEntity {
 
   @Column(nullable = false, length = 50)
   private String name;
-
-  @OneToMany(mappedBy = "studio", cascade = CascadeType.PERSIST)
-  private List<AnimeStudio> animeStudios;
 }

--- a/src/main/java/io/oduck/api/domain/studio/repository/StudioRepository.java
+++ b/src/main/java/io/oduck/api/domain/studio/repository/StudioRepository.java
@@ -1,0 +1,8 @@
+package io.oduck.api.domain.studio.repository;
+
+import io.oduck.api.domain.studio.entity.Studio;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudioRepository extends JpaRepository<Studio, Long> {
+
+}

--- a/src/main/java/io/oduck/api/domain/voiceActor/entity/VoiceActor.java
+++ b/src/main/java/io/oduck/api/domain/voiceActor/entity/VoiceActor.java
@@ -1,21 +1,21 @@
 package io.oduck.api.domain.voiceActor.entity;
 
-import io.oduck.api.domain.anime.entity.AnimeVoiceActor;
 import io.oduck.api.global.audit.BaseEntity;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class VoiceActor extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,7 +23,4 @@ public class VoiceActor extends BaseEntity {
 
   @Column(nullable = false, length = 50)
   private String name;
-
-  @OneToMany(mappedBy = "voiceActor", cascade = CascadeType.PERSIST)
-  private List<AnimeVoiceActor> animeVoiceActors;
 }

--- a/src/main/java/io/oduck/api/domain/voiceActor/repository/VoiceActorRepository.java
+++ b/src/main/java/io/oduck/api/domain/voiceActor/repository/VoiceActorRepository.java
@@ -1,0 +1,8 @@
+package io.oduck.api.domain.voiceActor.repository;
+
+import io.oduck.api.domain.voiceActor.entity.VoiceActor;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VoiceActorRepository extends JpaRepository<VoiceActor, Long> {
+
+}

--- a/src/test/java/io/oduck/api/unit/anime/repository/AnimeRepositoryTest.java
+++ b/src/test/java/io/oduck/api/unit/anime/repository/AnimeRepositoryTest.java
@@ -1,0 +1,499 @@
+package io.oduck.api.unit.anime.repository;
+
+import static io.oduck.api.global.utils.AnimeTestUtils.getBroadcastType;
+import static io.oduck.api.global.utils.AnimeTestUtils.getEpisodeCount;
+import static io.oduck.api.global.utils.AnimeTestUtils.getQuarter;
+import static io.oduck.api.global.utils.AnimeTestUtils.getRating;
+import static io.oduck.api.global.utils.AnimeTestUtils.getStatus;
+import static io.oduck.api.global.utils.AnimeTestUtils.getSummary;
+import static io.oduck.api.global.utils.AnimeTestUtils.getThumbnail;
+import static io.oduck.api.global.utils.AnimeTestUtils.getTitle;
+import static io.oduck.api.global.utils.AnimeTestUtils.getYear;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.oduck.api.domain.anime.entity.Anime;
+import io.oduck.api.domain.anime.entity.AnimeGenre;
+import io.oduck.api.domain.anime.entity.AnimeOriginalAuthor;
+import io.oduck.api.domain.anime.entity.AnimeStudio;
+import io.oduck.api.domain.anime.entity.AnimeVoiceActor;
+import io.oduck.api.domain.anime.repository.AnimeGenreRepository;
+import io.oduck.api.domain.anime.repository.AnimeOriginalAuthorRepository;
+import io.oduck.api.domain.anime.repository.AnimeRepository;
+import io.oduck.api.domain.anime.repository.AnimeStudioRepository;
+import io.oduck.api.domain.anime.repository.AnimeVoiceActorRepository;
+import io.oduck.api.domain.genre.entity.Genre;
+import io.oduck.api.domain.genre.repository.GenreRepository;
+import io.oduck.api.domain.originalAuthor.entity.OriginalAuthor;
+import io.oduck.api.domain.originalAuthor.repository.OriginalAuthorRepository;
+import io.oduck.api.domain.series.entity.Series;
+import io.oduck.api.domain.series.repository.SeriesRepository;
+import io.oduck.api.domain.studio.entity.Studio;
+import io.oduck.api.domain.studio.repository.StudioRepository;
+import io.oduck.api.domain.voiceActor.entity.VoiceActor;
+import io.oduck.api.domain.voiceActor.repository.VoiceActorRepository;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+public class AnimeRepositoryTest {
+    @Autowired
+    private AnimeRepository animeRepository;
+
+    @Autowired
+    private AnimeOriginalAuthorRepository animeOriginalAuthorRepository;
+
+    @Autowired
+    private OriginalAuthorRepository originalAuthorRepository;
+
+    @Autowired
+    private StudioRepository studioRepository;
+
+    @Autowired
+    private AnimeStudioRepository animeStudioRepository;
+
+    @Autowired
+    private VoiceActorRepository voiceActorRepository;
+
+    @Autowired
+    private AnimeVoiceActorRepository animeVoiceActorRepository;
+
+    @Autowired
+    private GenreRepository genreRepository;
+
+    @Autowired
+    private AnimeGenreRepository animeGenreRepository;
+
+    @Autowired
+    private SeriesRepository seriesRepository;
+
+    @Nested
+    @DisplayName("애니 등록")
+    class PostAnime{
+
+        @Test
+        @DisplayName("연관 관계 설정 성공")
+        void saveAnime(){
+            /**
+             * 원작 작가 연관 관계 설정
+             */
+            // 1. OriginalAuthor 생성 size=1
+            String originalAuthorName = "엔도 타츠야";
+            OriginalAuthor originalAuthor = OriginalAuthor.builder()
+                .name(originalAuthorName)
+                .build();
+            originalAuthorRepository.save(originalAuthor);
+
+            // 2. AnimeOriginalAuthor 생성
+            AnimeOriginalAuthor animeOriginalAuthor = AnimeOriginalAuthor.createAnimeOriginalAuthor(originalAuthor);
+
+            List<AnimeOriginalAuthor> animeOriginalAuthors = new ArrayList<>();
+            animeOriginalAuthors.add(animeOriginalAuthor);
+
+            /**
+             * 스튜디오 생성
+             */
+            // 1. Studio 생성 size=1
+            String studioName = "ufortable";
+            Studio studio = Studio.builder()
+                .name(studioName)
+                .build();
+            studioRepository.save(studio);
+
+            assertThat(studio.getName()).isEqualTo(studioName);
+
+            // 2. AnimeStudio 생성
+            AnimeStudio animeStudio = AnimeStudio.createAnimeStudio(studio);
+
+            List<AnimeStudio> animeStudios = new ArrayList<>();
+            animeStudios.add(animeStudio);
+
+            /**
+             * 성우 생성
+             */
+            // 1. VoiceActor 생성 size=5
+            int voiceActorSize = 5;
+
+            List<VoiceActor> voiceActors = new ArrayList<>();
+            for(int i = 0; i < voiceActorSize; i++){
+                VoiceActor voiceActor = VoiceActor.builder()
+                    .name("성우"+i)
+                    .build();
+                voiceActors.add(voiceActor);
+            }
+
+            voiceActorRepository.saveAll(voiceActors);
+
+            // 2. AnimeVoiceActor 생성
+            List<AnimeVoiceActor> animeVoiceActors = new ArrayList<>();
+            for (VoiceActor voiceActor : voiceActors) {
+                AnimeVoiceActor animeVoiceActor = AnimeVoiceActor.createAnimeVoiceActor("파트", voiceActor);
+                animeVoiceActors.add(animeVoiceActor);
+            }
+
+            /**
+             * 장르 생성
+             */
+            // 1. Genre 생성 size = 2
+            int genreSize = 2;
+
+            List<Genre> genres = new ArrayList<>();
+            for(int i = 0; i < genreSize; i++){
+                Genre genre = Genre.builder()
+                    .name("장르"+i)
+                    .build();
+                genres.add(genre);
+            }
+
+            genreRepository.saveAll(genres);
+
+            // 2. AnimeGenre 생성
+            List<AnimeGenre> animeGenres = new ArrayList<>();
+            for (Genre genre : genres) {
+                AnimeGenre animeGenre = AnimeGenre.createAnimeGenre(genre);
+                animeGenres.add(animeGenre);
+            }
+
+            /**
+             * 시리즈 생성
+             */
+            // 1. Series
+            String seriesTitle = "귀멸의 칼날";
+            Series series = Series.builder()
+                .title(seriesTitle)
+                .build();
+
+            // 2. Series 생성
+            seriesRepository.save(series);
+
+            // 애니 생성
+            Anime anime = Anime.createAnime(
+                getTitle(), getSummary(), getBroadcastType(), getEpisodeCount(), getThumbnail(),
+                getYear(), getQuarter(), getRating(), getStatus(), animeOriginalAuthors,
+                animeStudios, animeVoiceActors, animeGenres, series
+            );
+
+            Anime savedAnime = animeRepository.save(anime);
+
+            assertThat(savedAnime.getTitle()).isEqualTo(getTitle());
+            assertThat(savedAnime.getSummary()).isEqualTo(getSummary());
+            assertThat(savedAnime.getBroadcastType()).isEqualTo(getBroadcastType());
+            assertThat(savedAnime.getEpisodeCount()).isEqualTo(getEpisodeCount());
+            assertThat(savedAnime.getThumbnail()).isEqualTo(getThumbnail());
+            assertThat(savedAnime.getYear()).isEqualTo(getYear());
+            assertThat(savedAnime.getQuarter()).isEqualTo(getQuarter());
+            assertThat(savedAnime.getRating()).isEqualTo(getRating());
+            assertThat(savedAnime.getStatus()).isEqualTo(getStatus());
+            assertThat(savedAnime.isReleased()).isFalse();
+            assertThat(savedAnime.getViewCount()).isEqualTo(0);
+            assertThat(savedAnime.getReviewCount()).isEqualTo(0);
+            assertThat(savedAnime.getBookmarkCount()).isEqualTo(0);
+            assertThat(savedAnime.getStarRatingScoreTotal()).isEqualTo(0);
+
+            assertThat(savedAnime.getAnimeOriginalAuthors().size()).isEqualTo(1);
+            assertThat(savedAnime.getAnimeStudios().size()).isEqualTo(1);
+            assertThat(savedAnime.getAnimeVoiceActors().size()).isEqualTo(voiceActorSize);
+            assertThat(savedAnime.getAnimeGenres().size()).isEqualTo(genreSize);
+            assertThat(savedAnime.getSeries().getTitle()).isEqualTo(seriesTitle);
+        }
+
+        @Test
+        @DisplayName("연관 관계 설정 시 연결 테이블의 값이 없을 때")
+        void saveAnimeNoAnimeOriginalAuthor(){
+            List<AnimeOriginalAuthor> animeOriginalAuthors = new ArrayList<>();
+            List<AnimeStudio> animeStudios = new ArrayList<>();
+            List<AnimeVoiceActor> animeVoiceActors = new ArrayList<>();
+            List<AnimeGenre> animeGenres = new ArrayList<>();
+
+            Anime anime = Anime.createAnime(
+                getTitle(), getSummary(), getBroadcastType(), getEpisodeCount(), getThumbnail(),
+                getYear(), getQuarter(), getRating(), getStatus(), animeOriginalAuthors,
+                animeStudios, animeVoiceActors, animeGenres, null
+            );
+
+            Anime savedAnime = animeRepository.save(anime);
+            assertThat(savedAnime.getAnimeOriginalAuthors().isEmpty()).isTrue();
+            assertThat(savedAnime.getAnimeStudios().isEmpty()).isTrue();
+            assertThat(savedAnime.getAnimeVoiceActors().isEmpty()).isTrue();
+            assertThat(savedAnime.getAnimeGenres().isEmpty()).isTrue();
+            assertThat(savedAnime.getSeries()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("애니 수정")
+    class patchAnime{
+        @Test
+        @DisplayName("애니 원작 작가 수정 성공")
+        void changeAnimeOriginalAuthors(){
+            // given
+            // 초기 원작 작가 설정
+            String originalAuthorName = "작가";
+            int firstInsertSize = 2;
+
+            List<OriginalAuthor> originalAuthors = new ArrayList<>();
+            for(int i = 0; i < firstInsertSize; i++){
+                OriginalAuthor originalAuthor = OriginalAuthor.builder()
+                    .name(originalAuthorName)
+                    .build();
+                originalAuthors.add(originalAuthor);
+            }
+
+            originalAuthorRepository.saveAll(originalAuthors);
+
+            // 원작 작가와 애니 연관 관계 테이블 연관 관계 맺기
+            List<AnimeOriginalAuthor> animeOriginalAuthors = new ArrayList<>();
+            for (OriginalAuthor originalAuthor : originalAuthors) {
+                AnimeOriginalAuthor animeOriginalAuthor = AnimeOriginalAuthor.createAnimeOriginalAuthor(originalAuthor);
+                animeOriginalAuthors.add(animeOriginalAuthor);
+            }
+
+            List<AnimeStudio> animeStudios = new ArrayList<>();
+            List<AnimeVoiceActor> animeVoiceActors = new ArrayList<>();
+            List<AnimeGenre> animeGenres = new ArrayList<>();
+
+            // 애니 생성
+            Anime anime = Anime.createAnime(
+                getTitle(), getSummary(), getBroadcastType(), getEpisodeCount(), getThumbnail(),
+                getYear(), getQuarter(), getRating(), getStatus(), animeOriginalAuthors,
+                animeStudios, animeVoiceActors, animeGenres, null
+            );
+
+            Long savedAnimeId = animeRepository.saveAndFlush(anime).getId();
+
+            //when
+            //업데이트할 작가 생성
+            String updatingOriginalAuthorName = "유재석";
+            OriginalAuthor updatingOriginalAuthor = OriginalAuthor.builder()
+                .name(updatingOriginalAuthorName)
+                .build();
+            originalAuthorRepository.save(updatingOriginalAuthor);
+
+            List<AnimeOriginalAuthor> updatingAnimeOriginalAuthors = new ArrayList<>();
+            AnimeOriginalAuthor updatingAnimeOriginalAuthor = AnimeOriginalAuthor.createAnimeOriginalAuthor(updatingOriginalAuthor);
+            updatingAnimeOriginalAuthors.add(updatingAnimeOriginalAuthor);
+
+            // 애니 찾기
+            Anime findAnime = animeRepository.findById(savedAnimeId).get();
+
+            // 애니 수정
+            findAnime.assignAnimeOriginalAuthors(updatingAnimeOriginalAuthors);
+
+            Long findAnimeId = findAnime.getId();
+            List<AnimeOriginalAuthor> findAnimeOriginalAuthors = animeOriginalAuthorRepository
+                .findAllByAnimeId(findAnimeId);
+
+            // then
+            String findOriginalAuthorName = findAnime.getAnimeOriginalAuthors().get(0).getOriginalAuthor().getName();
+            assertThat(findOriginalAuthorName).isEqualTo(updatingOriginalAuthorName);
+            assertThat(findAnimeOriginalAuthors.size()).isNotEqualTo(firstInsertSize);
+            assertThat(findAnimeOriginalAuthors.size()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("애니 스튜디오 수정 성공")
+        void changeAnimeStudios(){
+            // given
+            // 초기 스튜디오 설정
+            String studioName = "스튜디오";
+            int firstInsertSize = 2;
+
+            List<Studio> studios = new ArrayList<>();
+            for(int i = 0; i<firstInsertSize; i++){
+                Studio studio = Studio.builder()
+                    .name(studioName)
+                    .build();
+                studios.add(studio);
+            }
+
+            studioRepository.saveAll(studios);
+
+            // 스튜디오와 애니 연관 관계 테이블 연관 관계 맺기
+            List<AnimeStudio> animeStudios = new ArrayList<>();
+            for (Studio studio : studios) {
+                AnimeStudio animeStudio = AnimeStudio.createAnimeStudio(studio);
+                animeStudios.add(animeStudio);
+            }
+
+            List<AnimeOriginalAuthor> animeOriginalAuthors = new ArrayList<>();
+            List<AnimeVoiceActor> animeVoiceActors = new ArrayList<>();
+            List<AnimeGenre> animeGenres = new ArrayList<>();
+
+            // 애니 생성
+            Anime anime = Anime.createAnime(
+                getTitle(), getSummary(), getBroadcastType(), getEpisodeCount(), getThumbnail(),
+                getYear(), getQuarter(), getRating(), getStatus(), animeOriginalAuthors,
+                animeStudios, animeVoiceActors, animeGenres, null
+            );
+
+            Long savedAnimeId = animeRepository.saveAndFlush(anime).getId();
+
+            //when
+            //업데이트할 스튜디오 생성
+            String updatingStudioName = "업데이트 스튜디오";
+            Studio updatingStudio = Studio.builder()
+                .name(updatingStudioName)
+                .build();
+            studioRepository.save(updatingStudio);
+
+            List<AnimeStudio> updatingAnimeStudios = new ArrayList<>();
+            AnimeStudio animeStudio = AnimeStudio.createAnimeStudio(updatingStudio);
+            updatingAnimeStudios.add(animeStudio);
+
+            // 애니 찾기
+            Anime findAnime = animeRepository.findById(savedAnimeId).get();
+
+            // 애니 수정
+            findAnime.assignAnimeStudios(updatingAnimeStudios);
+
+            Long findAnimeId = findAnime.getId();
+            List<AnimeStudio> findAnimeOriginalAuthors = animeStudioRepository.findAllByAnimeId(findAnimeId);
+
+            // then
+            String findStudioName = findAnime.getAnimeStudios().get(0).getStudio().getName();
+            assertThat(findStudioName).isEqualTo(updatingStudioName);
+            assertThat(findAnimeOriginalAuthors.size()).isNotEqualTo(firstInsertSize);
+            assertThat(findAnimeOriginalAuthors.size()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("애니 성우 수정 성공")
+        void changeAnimeVoiceActors(){
+            // given
+            // 초기 성우 설정
+            String voiceActorName = "성우";
+            int firstInsertSize = 2;
+
+            List<VoiceActor> voiceActors = new ArrayList<>();
+            for(int i = 0; i < firstInsertSize; i++){
+                VoiceActor voiceActor = VoiceActor.builder()
+                    .name(voiceActorName)
+                    .build();
+                voiceActors.add(voiceActor);
+            }
+
+            voiceActorRepository.saveAll(voiceActors);
+
+            // 성우와 애니 연관 관계 테이블 연관 관계 맺기
+            List<AnimeVoiceActor> animeVoiceActors = new ArrayList<>();
+            for (VoiceActor voiceActor : voiceActors) {
+                AnimeVoiceActor animeVoiceActor = AnimeVoiceActor.createAnimeVoiceActor("part", voiceActor);
+                animeVoiceActors.add(animeVoiceActor);
+            }
+
+            List<AnimeOriginalAuthor> animeOriginalAuthors = new ArrayList<>();
+            List<AnimeStudio> animeStudios = new ArrayList<>();
+            List<AnimeGenre> animeGenres = new ArrayList<>();
+
+            // 애니 생성
+            Anime anime = Anime.createAnime(
+                getTitle(), getSummary(), getBroadcastType(), getEpisodeCount(), getThumbnail(),
+                getYear(), getQuarter(), getRating(), getStatus(), animeOriginalAuthors,
+                animeStudios, animeVoiceActors, animeGenres, null
+            );
+
+            Long savedAnimeId = animeRepository.saveAndFlush(anime).getId();
+
+            //when
+            //업데이트할 성우 생성
+            String updatingVoiceActorName = "성우";
+            VoiceActor updatingVoiceActor = VoiceActor.builder()
+                .name(updatingVoiceActorName)
+                .build();
+            voiceActorRepository.save(updatingVoiceActor);
+
+            List<AnimeVoiceActor> updatingAnimeVoiceActors = new ArrayList<>();
+            AnimeVoiceActor animeVoiceActor = AnimeVoiceActor.createAnimeVoiceActor("part", updatingVoiceActor);
+            updatingAnimeVoiceActors.add(animeVoiceActor);
+
+            // 애니 찾기
+            Anime findAnime = animeRepository.findById(savedAnimeId).get();
+
+            // 애니 수정
+            findAnime.assignAnimeVoiceActors(updatingAnimeVoiceActors);
+
+            Long findAnimeId = findAnime.getId();
+            List<AnimeVoiceActor> findAnimeVoiceActors = animeVoiceActorRepository.findAllByAnimeId(findAnimeId);
+
+            // then
+            String firstVoiceActorName = findAnime.getAnimeVoiceActors().get(0).getVoiceActor().getName();
+            assertThat(firstVoiceActorName).isEqualTo(updatingVoiceActorName);
+            assertThat(findAnimeVoiceActors.size()).isNotEqualTo(firstInsertSize);
+            assertThat(findAnimeVoiceActors.size()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("애니 장르 수정 성공")
+        void changeAnimeGenres(){
+            // given
+            // 초기 장르 설정
+            String genreName = "장르";
+            int firstInsertSize = 2;
+
+            List<Genre> genres = new ArrayList<>();
+            for(int i = 0; i < firstInsertSize; i++){
+                Genre genre = Genre.builder()
+                    .name(genreName)
+                    .build();
+                genres.add(genre);
+            }
+
+            genreRepository.saveAll(genres);
+
+            // 장르와 애니 연관 관계 테이블 연관 관계 맺기
+            List<AnimeGenre> animeGenres = new ArrayList<>();
+            for (Genre genre : genres) {
+                AnimeGenre animeGenre = AnimeGenre.createAnimeGenre(genre);
+                animeGenres.add(animeGenre);
+            }
+
+            List<AnimeOriginalAuthor> animeOriginalAuthors = new ArrayList<>();
+            List<AnimeStudio> animeStudios = new ArrayList<>();
+            List<AnimeVoiceActor> animeVoiceActors = new ArrayList<>();
+
+            // 애니 생성
+            Anime anime = Anime.createAnime(
+                getTitle(), getSummary(), getBroadcastType(), getEpisodeCount(), getThumbnail(),
+                getYear(), getQuarter(), getRating(), getStatus(), animeOriginalAuthors,
+                animeStudios, animeVoiceActors, animeGenres, null
+            );
+
+            Long savedAnimeId = animeRepository.saveAndFlush(anime).getId();
+
+            //when
+            //업데이트할 장르 생성
+            String updatingGenreName = "판타지";
+            Genre updatingGenre = Genre.builder()
+                .name(updatingGenreName)
+                .build();
+            genreRepository.save(updatingGenre);
+
+            List<AnimeGenre> updatingAnimeGenres = new ArrayList<>();
+            AnimeGenre animeGenre = AnimeGenre.createAnimeGenre(updatingGenre);
+            updatingAnimeGenres.add(animeGenre);
+
+            // 애니 찾기
+            Anime findAnime = animeRepository.findById(savedAnimeId).get();
+
+            // 애니 수정
+            findAnime.assignAnimeGenre(updatingAnimeGenres);
+
+            Long findAnimeId = findAnime.getId();
+            List<AnimeGenre> findAnimeGenres = animeGenreRepository.findAllByAnimeId(findAnimeId);
+
+            // then
+            String firstGenreName = findAnime.getAnimeGenres().get(0).getGenre().getName();
+            assertThat(firstGenreName).isEqualTo(updatingGenreName);
+            assertThat(findAnimeGenres.size()).isNotEqualTo(firstInsertSize);
+            assertThat(findAnimeGenres.size()).isEqualTo(1);
+        }
+    }
+}


### PR DESCRIPTION
## 📝 개요

## 🚀 변경사항
1. 애니 연관 관계 추가 메소드
2. 애니 관련 리포지토리 추가
3. 애니 연결 엔티티, 애니 엔티티는 생성 시 로직을 태워야 해서 생성 메소드로 만들었습니다. 원작 작가, 성우, 스튜디오, 장르 엔티티는 빌더로 생성하도록 하였습니다.
4. 애니 연결 테이블에도 BaseEntity를 상속하도록 변경
5. 애니에 비즈니스 로직 추가

## 🔗 관련 이슈
#28 

## ➕ 기타
- 이제부터 애니와 관련된 비즈니스 로직 만드실 때 애니의 비즈니스 메소드 호출해주세요!
예) 애니 리뷰 작성 시 Anime의 `increaseReviewCount()`를 호출해주시면 되겠습니다😁

- 평가할 때 음수가 오면 `IllegalArgumentException`을 터트리는데 `CustomException`을 던질지 고민되더라구요. 의견 있으시면 변경하겠습니다~!

```java
  // 평가할 때 점수 합산(별점)
  public void increaseStarRatingScore(int score){
    if(score <= 0){
      throw new IllegalArgumentException("음수는 올 수 없습니다.");
    }
    starRatingScoreTotal += score;
  }

  // 평가를 지웠을 때 점수 합산(별점)
  public void decreaseStarRatingScore(int score){
    if(score <= 0){
      throw new IllegalArgumentException("음수는 올 수 없습니다.");
    }
    starRatingScoreTotal -= score;
  }
```