### PR TITLE
회원 프로필 조회시 memberId 추가 #34

### DIFF
--- a/src/main/java/io/oduck/api/domain/member/dto/MemberResDto.java
+++ b/src/main/java/io/oduck/api/domain/member/dto/MemberResDto.java
@@ -9,6 +9,7 @@ public class MemberResDto {
     @NoArgsConstructor
     public static class MemberProfileRes {
         private boolean isMine;
+        private Long memberId;
         private String name;
         private String description;
         private String thumbnail;
@@ -16,9 +17,10 @@ public class MemberResDto {
         private Activity activity;
 
         @Builder
-        public MemberProfileRes(boolean isMine, String name, String description, String thumbnail,
+        public MemberProfileRes(boolean isMine, Long memberId, String name, String description, String thumbnail,
             String backgroundImage, Activity activity) {
             this.isMine = isMine;
+            this.memberId = memberId;
             this.name = name;
             this.description = description;
             this.thumbnail = thumbnail;

--- a/src/main/java/io/oduck/api/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/io/oduck/api/domain/member/service/MemberServiceImpl.java
@@ -90,6 +90,7 @@ public class MemberServiceImpl implements MemberService{
 
         MemberProfileRes memberProfileRes = MemberProfileRes. builder()
             .isMine(memberProfile.getMemberId().equals(memberId))
+            .memberId(memberProfile.getMemberId())
             .name (memberProfile.getName())
             .description(memberProfile.getDescription())
             .thumbnail(memberProfile.getThumbnail())

--- a/src/test/java/io/oduck/api/e2e/member/MemberControllerTest.java
+++ b/src/test/java/io/oduck/api/e2e/member/MemberControllerTest.java
@@ -130,8 +130,9 @@ public class MemberControllerTest {
             // 응답 결과 검증 후 문서화
             actions
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.name").exists())
                     .andExpect(jsonPath("$.isMine").value(true))
+                    .andExpect(jsonPath("$.memberId").exists())
+                    .andExpect(jsonPath("$.name").exists())
                     .andExpect(jsonPath("$.description").exists())
                     .andExpect(jsonPath("$.thumbnail").exists())
                     .andExpect(jsonPath("$.backgroundImage").value(equalTo(null)))
@@ -153,12 +154,15 @@ public class MemberControllerTest {
                                     .description("Header Cookie, 세션 쿠키")
                             ),
                             responseFields(
-                                fieldWithPath("name")
-                                    .type(JsonFieldType.STRING)
-                                    .description("회원 이름"),
                                 fieldWithPath("isMine")
                                     .type(JsonFieldType.BOOLEAN)
                                     .description("본인 여부(본인 프로필 조회시 true)"),
+                                fieldWithPath("memberId")
+                                    .type(JsonFieldType.NUMBER)
+                                    .description("회원 id"),
+                                fieldWithPath("name")
+                                    .type(JsonFieldType.STRING)
+                                    .description("회원 이름"),
                                 fieldWithPath("description")
                                     .type(JsonFieldType.STRING)
                                     .description("자기 소개"),
@@ -209,8 +213,9 @@ public class MemberControllerTest {
             // 응답 결과 검증 후 문서화
             actions
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.name").exists())
                 .andExpect(jsonPath("$.isMine").value(false))
+                .andExpect(jsonPath("$.memberId").exists())
+                .andExpect(jsonPath("$.name").exists())
                 .andExpect(jsonPath("$.description").exists())
                 .andExpect(jsonPath("$.thumbnail").exists())
                 .andExpect(jsonPath("$.backgroundImage").value(equalTo(null)))
@@ -232,12 +237,15 @@ public class MemberControllerTest {
                             .description("Header Cookie, 세션 쿠키")
                     ),
                     responseFields(
-                        fieldWithPath("name")
-                            .type(JsonFieldType.STRING)
-                            .description("회원 이름"),
                         fieldWithPath("isMine")
                             .type(JsonFieldType.BOOLEAN)
                             .description("본인 여부(본인 프로필 조회시 true)"),
+                        fieldWithPath("memberId")
+                            .type(JsonFieldType.NUMBER)
+                            .description("회원 id"),
+                        fieldWithPath("name")
+                            .type(JsonFieldType.STRING)
+                            .description("회원 이름"),
                         fieldWithPath("description")
                             .type(JsonFieldType.STRING)
                             .description("자기 소개"),


### PR DESCRIPTION
## 📝 개요

회원 프로필 조회시 응답에 memberId 필드 추가


## 🚀 변경사항

1. memberProfileRes memberId 필드 추가
2. memberServiceImpl 로직 수정
3. 테스트 문서화에 memberId 필드 추가

## 🔗 관련 이슈

#34

## ➕ 기타
