### PR TITLE
원작 작가, 성우, 스튜디오, 장르 등록 및 조회 api #39

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -442,3 +442,198 @@ include::{snippets}/patchAnimeSeries/success/request-fields.adoc[]
 include::{snippets}/patchAnimeSeries/success/http-response.adoc[]
 
 ==== 실패시
+
+=== GET api/v1/oduckdmin/original-authors
+
+.curl-request
+include::{snippets}/getOriginalAuthors/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/getOriginalAuthors/success/http-request.adoc[]
+
+==== 성공시
+.http-response
+include::{snippets}/getOriginalAuthors/success/http-response.adoc[]
+
+.response-body
+include::{snippets}/getOriginalAuthors/success/response-body.adoc[]
+
+.response-fields
+include::{snippets}/getOriginalAuthors/success/response-fields.adoc[]
+
+==== 실패 시
+
+=== POST api/v1/oduckdmin/original-authors
+.curl-request
+include::{snippets}/postOriginalAuthor/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/postOriginalAuthor/success/http-request.adoc[]
+
+.request-body
+include::{snippets}/postOriginalAuthor/success/request-body.adoc[]
+
+.request-fields
+include::{snippets}/postOriginalAuthor/success/request-fields.adoc[]
+
+==== 성공 시
+.http-response
+include::{snippets}/postOriginalAuthor/success/http-response.adoc[]
+
+==== 실패 시
+
+=== GET api/v1/oduckdmin/voice-actors
+
+.curl-request
+include::{snippets}/getVoiceActors/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/getVoiceActors/success/http-request.adoc[]
+
+==== 성공시
+.http-response
+include::{snippets}/getVoiceActors/success/http-response.adoc[]
+
+.response-body
+include::{snippets}/getVoiceActors/success/response-body.adoc[]
+
+.response-fields
+include::{snippets}/getVoiceActors/success/response-fields.adoc[]
+
+==== 실패 시
+
+=== POST api/v1/oduckdmin/voice-actors
+.curl-request
+include::{snippets}/postVoiceActor/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/postVoiceActor/success/http-request.adoc[]
+
+.request-body
+include::{snippets}/postVoiceActor/success/request-body.adoc[]
+
+.request-fields
+include::{snippets}/postVoiceActor/success/request-fields.adoc[]
+
+==== 성공 시
+.http-response
+include::{snippets}/postVoiceActor/success/http-response.adoc[]
+
+==== 실패 시
+
+=== GET api/v1/oduckdmin/studios
+
+.curl-request
+include::{snippets}/getStudios/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/getStudios/success/http-request.adoc[]
+
+==== 성공시
+.http-response
+include::{snippets}/getStudios/success/http-response.adoc[]
+
+.response-body
+include::{snippets}/getStudios/success/response-body.adoc[]
+
+.response-fields
+include::{snippets}/getStudios/success/response-fields.adoc[]
+
+==== 실패 시
+
+=== POST api/v1/oduckdmin/studios
+.curl-request
+include::{snippets}/postStudio/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/postStudio/success/http-request.adoc[]
+
+.request-body
+include::{snippets}/postStudio/success/request-body.adoc[]
+
+.request-fields
+include::{snippets}/postStudio/success/request-fields.adoc[]
+
+==== 성공 시
+.http-response
+include::{snippets}/postStudio/success/http-response.adoc[]
+
+==== 실패 시
+
+=== GET api/v1/oduckdmin/genres
+
+.curl-request
+include::{snippets}/getGenres//success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/getGenres/success/http-request.adoc[]
+
+==== 성공시
+.http-response
+include::{snippets}/getGenres/success/http-response.adoc[]
+
+.response-body
+include::{snippets}/getGenres/success/response-body.adoc[]
+
+.response-fields
+include::{snippets}/getGenres/success/response-fields.adoc[]
+
+==== 실패 시
+
+=== POST api/v1/oduckdmin/genres
+.curl-request
+include::{snippets}/postGenre/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/postGenre/success/http-request.adoc[]
+
+.request-body
+include::{snippets}/postGenre/success/request-body.adoc[]
+
+.request-fields
+include::{snippets}/postGenre/success/request-fields.adoc[]
+
+==== 성공 시
+.http-response
+include::{snippets}/postGenre/success/http-response.adoc[]
+
+==== 실패 시
+
+=== GET api/v1/oduckdmin/series
+
+.curl-request
+include::{snippets}/getSeries//success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/getSeries/success/http-request.adoc[]
+
+==== 성공시
+.http-response
+include::{snippets}/getSeries/success/http-response.adoc[]
+
+.response-body
+include::{snippets}/getSeries/success/response-body.adoc[]
+
+.response-fields
+include::{snippets}/getSeries/success/response-fields.adoc[]
+
+==== 실패 시
+
+=== POST api/v1/oduckdmin/genres
+.curl-request
+include::{snippets}/postSeries/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/postSeries/success/http-request.adoc[]
+
+.request-body
+include::{snippets}/postSeries/success/request-body.adoc[]
+
+.request-fields
+include::{snippets}/postSeries/success/request-fields.adoc[]
+
+==== 성공 시
+.http-response
+include::{snippets}/postSeries/success/http-response.adoc[]
+
+==== 실패 시

--- a/src/main/java/io/oduck/api/domain/admin/controller/AdminController.java
+++ b/src/main/java/io/oduck/api/domain/admin/controller/AdminController.java
@@ -1,25 +1,30 @@
 package io.oduck.api.domain.admin.controller;
 
-import static io.oduck.api.domain.anime.dto.AnimeReq.PatchAnimeReq;
-import static io.oduck.api.domain.anime.dto.AnimeReq.PostReq;
-
-import io.oduck.api.domain.anime.dto.AnimeReq.PatchGenreIdsReq;
-import io.oduck.api.domain.anime.dto.AnimeReq.PatchOriginalAuthorIdsReq;
-import io.oduck.api.domain.anime.dto.AnimeReq.PatchSeriesIdReq;
-import io.oduck.api.domain.anime.dto.AnimeReq.PatchStudioIdsReq;
-import io.oduck.api.domain.anime.dto.AnimeReq.PatchVoiceActorIdsReq;
+import io.oduck.api.domain.anime.dto.AnimeReq;
 import io.oduck.api.domain.anime.service.AnimeService;
+import io.oduck.api.domain.genre.dto.GenreReq;
+import io.oduck.api.domain.genre.dto.GenreRes;
+import io.oduck.api.domain.genre.service.GenreService;
+import io.oduck.api.domain.originalAuthor.dto.OriginalAuthorReq;
+import io.oduck.api.domain.originalAuthor.dto.OriginalAuthorRes;
+import io.oduck.api.domain.originalAuthor.service.OriginalAuthorService;
+import io.oduck.api.domain.series.dto.SeriesReq;
+import io.oduck.api.domain.series.dto.SeriesRes;
+import io.oduck.api.domain.series.service.SeriesService;
+import io.oduck.api.domain.studio.dto.StudioReq;
+import io.oduck.api.domain.studio.dto.StudioRes;
+import io.oduck.api.domain.studio.service.StudioService;
+import io.oduck.api.domain.voiceActor.dto.VoiceActorReq;
+import io.oduck.api.domain.voiceActor.dto.VoiceActorRes;
+import io.oduck.api.domain.voiceActor.service.VoiceActorService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Validated
 @RestController
@@ -29,10 +34,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminController {
 
     private final AnimeService animeService;
+    private final OriginalAuthorService originalAuthorService;
+    private final VoiceActorService voiceActorService;
+    private final StudioService studioService;
+    private final GenreService genreService;
+    private final SeriesService seriesService;
 
     //애니 등록
     @PostMapping("/animes")
-    public ResponseEntity<Object> postAnime(@RequestBody @Valid PostReq req){
+    public ResponseEntity<Object> postAnime(@RequestBody @Valid AnimeReq.PostReq req){
 
         animeService.save(req);
 
@@ -42,7 +52,7 @@ public class AdminController {
     //애니 관련 수정
     @PatchMapping("/animes/{animeId}")
     public ResponseEntity<Object> patchAnime(
-        @PathVariable Long animeId, @RequestBody @Valid PatchAnimeReq req
+        @PathVariable Long animeId, @RequestBody @Valid AnimeReq.PatchAnimeReq req
     ){
 
         animeService.update(animeId, req);
@@ -53,7 +63,7 @@ public class AdminController {
     // 애니의 원작 작가 수정
     @PatchMapping("/animes/{animeId}/original-authors")
     public ResponseEntity<Object> patchAnimeOriginalAuthors(
-        @PathVariable Long animeId, @RequestBody PatchOriginalAuthorIdsReq req
+        @PathVariable Long animeId, @RequestBody AnimeReq.PatchOriginalAuthorIdsReq req
     ){
         animeService.updateAnimeOriginalAuthors(animeId, req);
 
@@ -63,7 +73,7 @@ public class AdminController {
     // 애니의 스튜디오 수정
     @PatchMapping("/animes/{animeId}/studios")
     public ResponseEntity<Object> patchAnimeStudios(
-        @PathVariable Long animeId, @RequestBody PatchStudioIdsReq req
+        @PathVariable Long animeId, @RequestBody AnimeReq.PatchStudioIdsReq req
     ){
 
         animeService.updateAnimeStudios(animeId, req);
@@ -73,7 +83,7 @@ public class AdminController {
     // 애니의 성우 수정
     @PatchMapping("/animes/{animeId}/voice-actors")
     public ResponseEntity<Object> patchAnimeVoiceActors(
-        @PathVariable Long animeId, @RequestBody PatchVoiceActorIdsReq req
+        @PathVariable Long animeId, @RequestBody AnimeReq.PatchVoiceActorIdsReq req
     ){
         animeService.updateAnimeVoiceActors(animeId, req);
 
@@ -83,7 +93,7 @@ public class AdminController {
     // 애니의 장르 수정
     @PatchMapping("/animes/{animeId}/genres")
     public ResponseEntity<Object> patchAnimeGenres(
-        @PathVariable Long animeId, @RequestBody PatchGenreIdsReq req
+        @PathVariable Long animeId, @RequestBody AnimeReq.PatchGenreIdsReq req
     ){
 
         animeService.updateAnimeGenres(animeId, req);
@@ -94,7 +104,7 @@ public class AdminController {
     // 애니의 시리즈 수정
     @PatchMapping("/animes/{animeId}/series")
     public ResponseEntity<Object> patchAnimeSeries(
-        @PathVariable Long animeId, @RequestBody PatchSeriesIdReq req
+        @PathVariable Long animeId, @RequestBody AnimeReq.PatchSeriesIdReq req
     ){
 
         animeService.updateSeries(animeId, req);
@@ -122,4 +132,84 @@ public class AdminController {
 //        return ResponseEntity
 //            .ok(PageResponse.of(null));
 //    }
+
+    @GetMapping("/original-authors")
+    public ResponseEntity<Object> getOriginalAuthors(){
+
+        List<OriginalAuthorRes> originalAuthors = originalAuthorService.getOriginalAuthors();
+
+        return ResponseEntity.ok(originalAuthors);
+    }
+
+    @PostMapping("/original-authors")
+    public ResponseEntity<Object> postOriginalAuthor(@RequestBody @Valid OriginalAuthorReq.PostReq req) {
+
+        originalAuthorService.save(req);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/voice-actors")
+    public ResponseEntity<Object> getVoiceActors() {
+
+        List<VoiceActorRes> voiceActors = voiceActorService.getVoiceActors();
+
+        return ResponseEntity.ok(voiceActors);
+    }
+
+    @PostMapping("/voice-actors")
+    public ResponseEntity<Object> postVoiceActor(@RequestBody @Valid VoiceActorReq.PostReq req) {
+
+        voiceActorService.save(req);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/studios")
+    public ResponseEntity<Object> getStudios() {
+
+        List<StudioRes> studios = studioService.getStudios();
+
+        return ResponseEntity.ok(studios);
+    }
+
+    @PostMapping("/studios")
+    public ResponseEntity<Object> postStudio(@RequestBody @Valid StudioReq.PostReq req) {
+
+        studioService.save(req);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/genres")
+    public ResponseEntity<Object> getGenres(){
+
+        List<GenreRes> genres = genreService.getGenres();
+
+        return ResponseEntity.ok(genres);
+    }
+
+    @PostMapping("/genres")
+    public ResponseEntity<Object> postGenre(@RequestBody @Valid GenreReq.PostReq req) {
+
+        genreService.save(req);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/series")
+    public ResponseEntity<Object> getSeries() {
+
+        List<SeriesRes> seriesList = seriesService.getSeries();
+
+        return ResponseEntity.ok(seriesList);
+    }
+
+    @PostMapping("/series")
+    public ResponseEntity<Object> postSeries(@RequestBody @Valid SeriesReq.PostReq req) {
+
+        seriesService.save(req);
+
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/io/oduck/api/domain/anime/dto/AnimeReq.java
+++ b/src/main/java/io/oduck/api/domain/anime/dto/AnimeReq.java
@@ -6,6 +6,7 @@ import io.oduck.api.domain.anime.entity.Rating;
 import io.oduck.api.domain.anime.entity.Status;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,33 +20,34 @@ public class AnimeReq {
     @Getter
     public static class PostReq {
         @NotBlank
-        @Length(min = 1, max = 50,
-            message = "글자 수는 0~50을 허용합니다.")
+        @Length(min = 1, max = 50, message = "글자 수는 0~50을 허용합니다.")
         private String title;
 
         @NotBlank
-        @Length(min = 1, max = 255,
-            message = "글자 수는 0~255를 허용합니다.")
+        @Length(min = 1, max = 255, message = "글자 수는 0~255를 허용합니다.")
         private String summary;
 
+        @NotNull
         private BroadcastType broadcastType;
 
-        @Min(value = 0,
-            message = "음수가 올 수 없습니다.")
+        @NotNull(message = "에피소드 수를 입력하세요.")
+        @Min(value = 0, message = "음수가 올 수 없습니다.")
         private int episodeCount;
 
-        @NotBlank(
-            message = "섬네일을 입력하세요.")
+        @NotBlank(message = "섬네일을 입력하세요.")
         private String thumbnail;
 
-        @Min(value = 1900,
-            message = "1900년대 이상을 입력하세요.")
+        @NotNull(message = "년도를 입력하세요.")
+        @Min(value = 1900, message = "1900년대 이상을 입력하세요.")
         private int year;
 
+        @NotNull(message = "분기를 입력하세요.")
         private Quarter quarter;
 
+        @NotNull(message = "심의를 입력하세요.")
         private Rating rating;
 
+        @NotNull(message = "방영 상태를 입력하세요.")
         private Status status;
 
         private List<Long> originalAuthorIds;
@@ -105,33 +107,34 @@ public class AnimeReq {
     @AllArgsConstructor
     public static class PatchAnimeReq{
         @NotBlank
-        @Length(min = 1, max = 50,
-            message = "글자 수는 0~50을 허용합니다.")
+        @Length(min = 1, max = 50, message = "글자 수는 0~50을 허용합니다.")
         private String title;
 
         @NotBlank
-        @Length(min = 1, max = 255,
-            message = "글자 수는 0~255를 허용합니다.")
+        @Length(min = 1, max = 255, message = "글자 수는 0~255를 허용합니다.")
         private String summary;
 
+        @NotNull
         private BroadcastType broadcastType;
 
-        @Min(value = 0,
-            message = "음수가 올 수 없습니다.")
+        @NotNull(message = "에피소드 수를 입력하세요.")
+        @Min(value = 0, message = "음수가 올 수 없습니다.")
         private int episodeCount;
 
-        @NotBlank(
-            message = "섬네일을 입력하세요.")
+        @NotBlank(message = "섬네일을 입력하세요.")
         private String thumbnail;
 
-        @Min(value = 1900,
-            message = "1900년대 이상을 입력하세요.")
+        @NotNull(message = "년도를 입력하세요.")
+        @Min(value = 1900, message = "1900년대 이상을 입력하세요.")
         private int year;
 
+        @NotNull(message = "분기를 입력하세요.")
         private Quarter quarter;
 
+        @NotNull(message = "심의를 입력하세요.")
         private Rating rating;
 
+        @NotNull(message = "방영 상태를 입력하세요.")
         private Status status;
     }
 

--- a/src/main/java/io/oduck/api/domain/anime/dto/AnimeReq.java
+++ b/src/main/java/io/oduck/api/domain/anime/dto/AnimeReq.java
@@ -6,12 +6,13 @@ import io.oduck.api.domain.anime.entity.Rating;
 import io.oduck.api.domain.anime.entity.Status;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class AnimeReq {
 
@@ -51,7 +52,7 @@ public class AnimeReq {
 
         private List<Long> studioIds;
 
-        private List<VoiceActorReq> voiceActors;
+        private List<AnimeVoiceActorReq> voiceActors;
 
         private List<Long> genreIds;
 
@@ -59,7 +60,7 @@ public class AnimeReq {
 
         public PostReq (String title, String summary, BroadcastType broadcastType,
             int episodeCount, String thumbnail, int year, Quarter quarter, Rating rating, Status status,
-            List<Long> originalAuthorIds, List<Long> studioIds, List<VoiceActorReq> voiceActors,
+            List<Long> originalAuthorIds, List<Long> studioIds, List<AnimeVoiceActorReq> voiceActors,
             List<Long> genreIds, Long seriesId) {
 
             this.title = title;
@@ -166,9 +167,9 @@ public class AnimeReq {
     @Getter
     @NoArgsConstructor
     public static class PatchVoiceActorIdsReq {
-        private List<VoiceActorReq> voiceActors;
+        private List<AnimeVoiceActorReq> voiceActors;
 
-        public PatchVoiceActorIdsReq(List<VoiceActorReq> voiceActors) {
+        public PatchVoiceActorIdsReq(List<AnimeVoiceActorReq> voiceActors) {
             if(voiceActors == null){
                 this.voiceActors = new ArrayList<>();
             }else{

--- a/src/main/java/io/oduck/api/domain/anime/dto/AnimeRes.java
+++ b/src/main/java/io/oduck/api/domain/anime/dto/AnimeRes.java
@@ -27,7 +27,7 @@ public class AnimeRes {
     private Status status;
 
     private List<String> originalAuthors;
-    private List<VoiceActorRes> voiceActors;
+    private List<AnimeVoiceActorRes> voiceActors;
     private List<String> genres;
     private List<String> studios;
     private long reviewCount;
@@ -50,7 +50,7 @@ public class AnimeRes {
             .map(aoa -> aoa.getOriginalAuthor().getName())
             .collect(Collectors.toList());
         voiceActors = animeVoiceActors.stream()
-            .map(ava -> new VoiceActorRes(ava.getVoiceActor().getName(), ava.getPart()))
+            .map(ava -> new AnimeVoiceActorRes(ava.getVoiceActor().getName(), ava.getPart()))
             .collect(Collectors.toList());
         genres = animeGenres.stream()
             .map(ag -> ag.getGenre().getName())

--- a/src/main/java/io/oduck/api/domain/anime/dto/AnimeVoiceActorReq.java
+++ b/src/main/java/io/oduck/api/domain/anime/dto/AnimeVoiceActorReq.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class VoiceActorRes {
-    private String name;
+public class AnimeVoiceActorReq {
+    private Long id;
     private String part;
 }

--- a/src/main/java/io/oduck/api/domain/anime/dto/AnimeVoiceActorRes.java
+++ b/src/main/java/io/oduck/api/domain/anime/dto/AnimeVoiceActorRes.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class VoiceActorReq {
-    private Long id;
+public class AnimeVoiceActorRes {
+    private String name;
     private String part;
 }

--- a/src/main/java/io/oduck/api/domain/anime/service/AnimeServiceImpl.java
+++ b/src/main/java/io/oduck/api/domain/anime/service/AnimeServiceImpl.java
@@ -8,7 +8,7 @@ import io.oduck.api.domain.anime.dto.AnimeReq.PatchStudioIdsReq;
 import io.oduck.api.domain.anime.dto.AnimeReq.PatchVoiceActorIdsReq;
 import io.oduck.api.domain.anime.dto.AnimeReq.PostReq;
 import io.oduck.api.domain.anime.dto.AnimeRes;
-import io.oduck.api.domain.anime.dto.VoiceActorReq;
+import io.oduck.api.domain.anime.dto.AnimeVoiceActorReq;
 import io.oduck.api.domain.anime.entity.Anime;
 import io.oduck.api.domain.anime.entity.AnimeGenre;
 import io.oduck.api.domain.anime.entity.AnimeOriginalAuthor;
@@ -84,18 +84,18 @@ public class AnimeServiceImpl implements AnimeService{
             .collect(Collectors.toList());
 
         // 애니에 참여한 성우 리스트
-        List<VoiceActorReq> voiceActorDtoList = postReq.getVoiceActors();
+        List<AnimeVoiceActorReq> voiceActorDtoList = postReq.getVoiceActors();
 
         // 성우의 아이디 리스트 구하기
         List<Long> voiceActorIds = voiceActorDtoList.stream()
-            .map(VoiceActorReq::getId)
+            .map(AnimeVoiceActorReq::getId)
             .collect(Collectors.toList());
 
         List<VoiceActor> voiceActors = voiceActorRepository.findAllById(voiceActorIds);
 
         // Id와 Part로 구성된 map 생성
         Map<Long, String> voiceActorDtoMap = voiceActorDtoList.stream()
-            .collect(Collectors.toMap(VoiceActorReq::getId, VoiceActorReq::getPart));
+            .collect(Collectors.toMap(AnimeVoiceActorReq::getId, AnimeVoiceActorReq::getPart));
 
         List<AnimeVoiceActor> animeVoiceActors = voiceActors.stream()
             .filter(voiceActor -> voiceActorDtoMap.containsKey(voiceActor.getId()))
@@ -182,18 +182,18 @@ public class AnimeServiceImpl implements AnimeService{
         Anime anime = findAnime(animeId);
 
         // 애니에 참여한 성우 리스트
-        List<VoiceActorReq> voiceActorDtoList = patchReq.getVoiceActors();
+        List<AnimeVoiceActorReq> voiceActorDtoList = patchReq.getVoiceActors();
 
         // 성우의 아이디 리스트 구하기
         List<Long> voiceActorIds = voiceActorDtoList.stream()
-            .map(VoiceActorReq::getId)
+            .map(AnimeVoiceActorReq::getId)
             .collect(Collectors.toList());
 
         List<VoiceActor> voiceActors = voiceActorRepository.findAllById(voiceActorIds);
 
         // Id와 Part로 구성된 map 생성
         Map<Long, String> voiceActorDtoMap = voiceActorDtoList.stream()
-            .collect(Collectors.toMap(VoiceActorReq::getId, VoiceActorReq::getPart));
+            .collect(Collectors.toMap(AnimeVoiceActorReq::getId, AnimeVoiceActorReq::getPart));
 
         List<AnimeVoiceActor> animeVoiceActors = voiceActors.stream()
             .filter(va -> voiceActorDtoMap.containsKey(va.getId()))

--- a/src/main/java/io/oduck/api/domain/genre/dto/GenreReq.java
+++ b/src/main/java/io/oduck/api/domain/genre/dto/GenreReq.java
@@ -1,0 +1,20 @@
+package io.oduck.api.domain.genre.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+public class GenreReq {
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class PostReq {
+        @NotBlank
+        @Length(min = 1, max = 50,
+                message = "글자 수는 0~50을 허용합니다.")
+        private String name;
+    }
+}

--- a/src/main/java/io/oduck/api/domain/genre/dto/GenreRes.java
+++ b/src/main/java/io/oduck/api/domain/genre/dto/GenreRes.java
@@ -1,0 +1,11 @@
+package io.oduck.api.domain.genre.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GenreRes {
+    private Long id;
+    private String name;
+}

--- a/src/main/java/io/oduck/api/domain/genre/service/GenreService.java
+++ b/src/main/java/io/oduck/api/domain/genre/service/GenreService.java
@@ -1,5 +1,14 @@
 package io.oduck.api.domain.genre.service;
 
+import io.oduck.api.domain.genre.dto.GenreRes;
+
+import java.util.List;
+
+import static io.oduck.api.domain.genre.dto.GenreReq.PostReq;
+
 public interface GenreService {
 
+    void save(PostReq req);
+
+    List<GenreRes> getGenres();
 }

--- a/src/main/java/io/oduck/api/domain/genre/service/GenreServiceImpl.java
+++ b/src/main/java/io/oduck/api/domain/genre/service/GenreServiceImpl.java
@@ -1,10 +1,17 @@
 package io.oduck.api.domain.genre.service;
 
+import io.oduck.api.domain.genre.dto.GenreRes;
+import io.oduck.api.domain.genre.entity.Genre;
 import io.oduck.api.domain.genre.repository.GenreRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static io.oduck.api.domain.genre.dto.GenreReq.PostReq;
 
 @Service
 @RequiredArgsConstructor
@@ -13,4 +20,20 @@ import org.springframework.transaction.annotation.Transactional;
 public class GenreServiceImpl implements GenreService{
 
     private final GenreRepository genreRepository;
+
+    @Override
+    public void save(PostReq req) {
+        Genre genre = Genre.builder()
+                .name(req.getName())
+                .build();
+        genreRepository.save(genre);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<GenreRes> getGenres() {
+        return genreRepository.findAll().stream()
+                .map(gr -> new GenreRes(gr.getId(), gr.getName()))
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/io/oduck/api/domain/originalAuthor/dto/OriginalAuthorReq.java
+++ b/src/main/java/io/oduck/api/domain/originalAuthor/dto/OriginalAuthorReq.java
@@ -1,0 +1,20 @@
+package io.oduck.api.domain.originalAuthor.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+public class OriginalAuthorReq {
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class PostReq {
+        @NotBlank
+        @Length(min = 1, max = 50,
+        message = "글자 수는 0~50을 허용합니다.")
+        private String name;
+    }
+}

--- a/src/main/java/io/oduck/api/domain/originalAuthor/dto/OriginalAuthorRes.java
+++ b/src/main/java/io/oduck/api/domain/originalAuthor/dto/OriginalAuthorRes.java
@@ -1,0 +1,11 @@
+package io.oduck.api.domain.originalAuthor.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OriginalAuthorRes {
+    private Long id;
+    private String name;
+}

--- a/src/main/java/io/oduck/api/domain/originalAuthor/service/OriginalAuthorService.java
+++ b/src/main/java/io/oduck/api/domain/originalAuthor/service/OriginalAuthorService.java
@@ -1,5 +1,14 @@
 package io.oduck.api.domain.originalAuthor.service;
 
+import io.oduck.api.domain.originalAuthor.dto.OriginalAuthorRes;
+
+import java.util.List;
+
+import static io.oduck.api.domain.originalAuthor.dto.OriginalAuthorReq.PostReq;
+
 public interface OriginalAuthorService {
 
+    void save(PostReq req);
+
+    List<OriginalAuthorRes> getOriginalAuthors();
 }

--- a/src/main/java/io/oduck/api/domain/originalAuthor/service/OriginalAuthorServiceImpl.java
+++ b/src/main/java/io/oduck/api/domain/originalAuthor/service/OriginalAuthorServiceImpl.java
@@ -1,10 +1,17 @@
 package io.oduck.api.domain.originalAuthor.service;
 
+import io.oduck.api.domain.originalAuthor.dto.OriginalAuthorRes;
+import io.oduck.api.domain.originalAuthor.entity.OriginalAuthor;
 import io.oduck.api.domain.originalAuthor.repository.OriginalAuthorRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static io.oduck.api.domain.originalAuthor.dto.OriginalAuthorReq.PostReq;
 
 @Service
 @RequiredArgsConstructor
@@ -13,4 +20,22 @@ import org.springframework.transaction.annotation.Transactional;
 public class OriginalAuthorServiceImpl implements OriginalAuthorService{
 
     private final OriginalAuthorRepository originalAuthorRepository;
+
+    @Override
+    public void save(PostReq req) {
+
+        OriginalAuthor originalAuthor = OriginalAuthor.builder()
+                .name(req.getName())
+                .build();
+        originalAuthorRepository.save(originalAuthor);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<OriginalAuthorRes> getOriginalAuthors() {
+
+        return originalAuthorRepository.findAll().stream()
+                .map(oa -> new OriginalAuthorRes(oa.getId(), oa.getName()))
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/io/oduck/api/domain/series/dto/SeriesReq.java
+++ b/src/main/java/io/oduck/api/domain/series/dto/SeriesReq.java
@@ -1,0 +1,20 @@
+package io.oduck.api.domain.series.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+public class SeriesReq {
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class PostReq {
+        @NotBlank
+        @Length(min = 1, max = 50,
+                message = "글자 수는 0~50을 허용합니다.")
+        private String title;
+    }
+}

--- a/src/main/java/io/oduck/api/domain/series/dto/SeriesRes.java
+++ b/src/main/java/io/oduck/api/domain/series/dto/SeriesRes.java
@@ -1,0 +1,11 @@
+package io.oduck.api.domain.series.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SeriesRes {
+    private Long id;
+    private String title;
+}

--- a/src/main/java/io/oduck/api/domain/series/service/SeriesService.java
+++ b/src/main/java/io/oduck/api/domain/series/service/SeriesService.java
@@ -1,5 +1,14 @@
 package io.oduck.api.domain.series.service;
 
+import io.oduck.api.domain.series.dto.SeriesRes;
+
+import java.util.List;
+
+import static io.oduck.api.domain.series.dto.SeriesReq.PostReq;
+
 public interface SeriesService {
 
+    void save(PostReq req);
+
+    List<SeriesRes> getSeries();
 }

--- a/src/main/java/io/oduck/api/domain/series/service/SeriesServiceImpl.java
+++ b/src/main/java/io/oduck/api/domain/series/service/SeriesServiceImpl.java
@@ -1,10 +1,17 @@
 package io.oduck.api.domain.series.service;
 
+import io.oduck.api.domain.series.dto.SeriesRes;
+import io.oduck.api.domain.series.entity.Series;
 import io.oduck.api.domain.series.repository.SeriesRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static io.oduck.api.domain.series.dto.SeriesReq.PostReq;
 
 @Service
 @RequiredArgsConstructor
@@ -13,4 +20,20 @@ import org.springframework.transaction.annotation.Transactional;
 public class SeriesServiceImpl implements SeriesService{
 
     private final SeriesRepository seriesRepository;
+
+    @Override
+    public void save(PostReq req) {
+        Series series = Series.builder()
+                .title(req.getTitle())
+                .build();
+        seriesRepository.save(series);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<SeriesRes> getSeries() {
+        return seriesRepository.findAll().stream()
+                .map(s -> new SeriesRes(s.getId(), s.getTitle()))
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/io/oduck/api/domain/studio/dto/StudioReq.java
+++ b/src/main/java/io/oduck/api/domain/studio/dto/StudioReq.java
@@ -1,0 +1,20 @@
+package io.oduck.api.domain.studio.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+public class StudioReq {
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class PostReq {
+        @NotBlank
+        @Length(min = 1, max = 50,
+                message = "글자 수는 0~50을 허용합니다.")
+        private String name;
+    }
+}

--- a/src/main/java/io/oduck/api/domain/studio/dto/StudioRes.java
+++ b/src/main/java/io/oduck/api/domain/studio/dto/StudioRes.java
@@ -1,0 +1,11 @@
+package io.oduck.api.domain.studio.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class StudioRes {
+    private Long id;
+    private String name;
+}

--- a/src/main/java/io/oduck/api/domain/studio/service/StudioService.java
+++ b/src/main/java/io/oduck/api/domain/studio/service/StudioService.java
@@ -1,4 +1,13 @@
 package io.oduck.api.domain.studio.service;
 
+import io.oduck.api.domain.studio.dto.StudioRes;
+
+import java.util.List;
+
+import static io.oduck.api.domain.studio.dto.StudioReq.PostReq;
+
 public interface StudioService {
+    void save(PostReq req);
+
+    List<StudioRes> getStudios();
 }

--- a/src/main/java/io/oduck/api/domain/studio/service/StudioServiceImpl.java
+++ b/src/main/java/io/oduck/api/domain/studio/service/StudioServiceImpl.java
@@ -1,10 +1,16 @@
 package io.oduck.api.domain.studio.service;
 
+import io.oduck.api.domain.studio.dto.StudioReq;
+import io.oduck.api.domain.studio.dto.StudioRes;
+import io.oduck.api.domain.studio.entity.Studio;
 import io.oduck.api.domain.studio.repository.StudioRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -14,4 +20,19 @@ public class StudioServiceImpl implements StudioService{
 
     private final StudioRepository studioRepository;
 
+    @Override
+    public void save(StudioReq.PostReq req) {
+        Studio studio = Studio.builder()
+                .name(req.getName())
+                .build();
+        studioRepository.save(studio);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<StudioRes> getStudios() {
+        return studioRepository.findAll().stream()
+                .map(st -> new StudioRes(st.getId(), st.getName()))
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/io/oduck/api/domain/voiceActor/dto/VoiceActorReq.java
+++ b/src/main/java/io/oduck/api/domain/voiceActor/dto/VoiceActorReq.java
@@ -1,0 +1,20 @@
+package io.oduck.api.domain.voiceActor.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+public class VoiceActorReq {
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class PostReq {
+        @NotBlank
+        @Length(min = 1, max = 50,
+                message = "글자 수는 0~50을 허용합니다.")
+        private String name;
+    }
+}

--- a/src/main/java/io/oduck/api/domain/voiceActor/dto/VoiceActorRes.java
+++ b/src/main/java/io/oduck/api/domain/voiceActor/dto/VoiceActorRes.java
@@ -1,0 +1,11 @@
+package io.oduck.api.domain.voiceActor.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class VoiceActorRes {
+    private Long id;
+    private String name;
+}

--- a/src/main/java/io/oduck/api/domain/voiceActor/service/VoiceActorService.java
+++ b/src/main/java/io/oduck/api/domain/voiceActor/service/VoiceActorService.java
@@ -1,4 +1,15 @@
 package io.oduck.api.domain.voiceActor.service;
 
+import io.oduck.api.domain.voiceActor.dto.VoiceActorRes;
+
+import java.util.List;
+
+import static io.oduck.api.domain.voiceActor.dto.VoiceActorReq.PostReq;
+
 public interface VoiceActorService {
+
+    void save(PostReq req);
+
+    List<VoiceActorRes> getVoiceActors();
+
 }

--- a/src/main/java/io/oduck/api/domain/voiceActor/service/VoiceActorServiceImpl.java
+++ b/src/main/java/io/oduck/api/domain/voiceActor/service/VoiceActorServiceImpl.java
@@ -1,10 +1,17 @@
 package io.oduck.api.domain.voiceActor.service;
 
+import io.oduck.api.domain.voiceActor.dto.VoiceActorRes;
+import io.oduck.api.domain.voiceActor.entity.VoiceActor;
 import io.oduck.api.domain.voiceActor.repository.VoiceActorRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static io.oduck.api.domain.voiceActor.dto.VoiceActorReq.PostReq;
 
 @Service
 @RequiredArgsConstructor
@@ -13,4 +20,20 @@ import org.springframework.transaction.annotation.Transactional;
 public class VoiceActorServiceImpl implements VoiceActorService{
 
     private final VoiceActorRepository voiceActorRepository;
+
+    @Override
+    public void save(PostReq req) {
+        VoiceActor voiceActor = VoiceActor.builder()
+                .name(req.getName())
+                .build();
+        voiceActorRepository.save(voiceActor);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<VoiceActorRes> getVoiceActors() {
+        return voiceActorRepository.findAll().stream()
+                .map(va -> new VoiceActorRes(va.getId(), va.getName()))
+                .collect(Collectors.toList());
+    }
 }

--- a/src/test/java/io/oduck/api/e2e/admin/AdminControllerTest.java
+++ b/src/test/java/io/oduck/api/e2e/admin/AdminControllerTest.java
@@ -1,32 +1,14 @@
 package io.oduck.api.e2e.admin;
 
-import static io.oduck.api.global.config.RestDocsConfig.field;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.restdocs.snippet.Attributes.attributes;
-import static org.springframework.restdocs.snippet.Attributes.key;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.google.gson.Gson;
-import io.oduck.api.domain.anime.dto.AnimeReq.PatchAnimeReq;
-import io.oduck.api.domain.anime.dto.AnimeReq.PatchGenreIdsReq;
-import io.oduck.api.domain.anime.dto.AnimeReq.PatchOriginalAuthorIdsReq;
-import io.oduck.api.domain.anime.dto.AnimeReq.PatchSeriesIdReq;
-import io.oduck.api.domain.anime.dto.AnimeReq.PatchStudioIdsReq;
-import io.oduck.api.domain.anime.dto.AnimeReq.PatchVoiceActorIdsReq;
-import io.oduck.api.domain.anime.dto.AnimeReq.PostReq;
-import io.oduck.api.domain.anime.dto.VoiceActorReq;
+import io.oduck.api.domain.anime.dto.AnimeReq.*;
+import io.oduck.api.domain.anime.dto.AnimeVoiceActorReq;
+import io.oduck.api.domain.genre.dto.GenreReq;
+import io.oduck.api.domain.originalAuthor.dto.OriginalAuthorReq;
+import io.oduck.api.domain.series.dto.SeriesReq;
+import io.oduck.api.domain.studio.dto.StudioReq;
+import io.oduck.api.domain.voiceActor.dto.VoiceActorReq;
 import io.oduck.api.global.utils.AnimeTestUtils;
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -37,16 +19,33 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static io.oduck.api.global.config.RestDocsConfig.field;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.snippet.Attributes.attributes;
+import static org.springframework.restdocs.snippet.Attributes.key;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureRestDocs
 @AutoConfigureMockMvc
 @ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
 @SpringBootTest
+@Transactional
 @ActiveProfiles("test")
 public class AdminControllerTest {
     @Autowired
@@ -58,11 +57,11 @@ public class AdminControllerTest {
     private final static String ADMIN_URL = "/oduckdmin";
 
     @Nested
-    @DisplayName("등록")
-    class PostAnime{
+    @DisplayName("애니")
+    class AnimeTest{
 
         @Test
-        @DisplayName("성공 시 Http Status 200 반환")
+        @DisplayName("등록 성공 시 Http Status 200 반환")
         void postAnime() throws Exception {
             //given
             PostReq request = AnimeTestUtils.createPostAnimeRequest();
@@ -156,11 +155,6 @@ public class AdminControllerTest {
                 ));
         }
         //TODO : 애니 등록 실패 시
-    }
-
-    @Nested
-    @DisplayName("수정")
-    class PatchAnime{
 
         @Test
         @DisplayName("애니 수정 성공 시 Http Status 204 반환")
@@ -172,60 +166,60 @@ public class AdminControllerTest {
 
             //when
             ResultActions actions = mockMvc.perform(
-                patch(ADMIN_URL+"/animes/{animeId}", animeId)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .content(content)
+                    patch(ADMIN_URL+"/animes/{animeId}", animeId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .content(content)
             );
 
             //then
             actions
-                .andExpect(status().isNoContent())
-                .andDo(document("patchAnime/success",
-                    preprocessRequest(prettyPrint()),
-                    preprocessResponse(prettyPrint()),
-                    pathParameters(
-                        parameterWithName("animeId").description("애니의 식별자")
-                    ),
-                    requestFields(attributes(key("title").value("Fields for anime creation")),
-                        fieldWithPath("title")
-                            .type(JsonFieldType.STRING)
-                            .attributes(field("constraints", "공백을 허용하지 않습니다. 1~50자를 허용합니다."))
-                            .description("애니의 제목"),
-                        fieldWithPath("summary")
-                            .type(JsonFieldType.STRING)
-                            .attributes(field("constraints", "공백을 허용하지 않습니다. 1~255자를 허용합니다."))
-                            .description("애니 요약 설명"),
-                        fieldWithPath("broadcastType")
-                            .type(JsonFieldType.STRING)
-                            .attributes(field("constraints", "TVA,ONA,OVA,MOV만 허용합니다."))
-                            .description("애니 방송사"),
-                        fieldWithPath("episodeCount")
-                            .type(JsonFieldType.NUMBER)
-                            .attributes(field("constraints", "0 이상의 숫자만 허용합니다."))
-                            .description("애피소드 화수"),
-                        fieldWithPath("thumbnail")
-                            .type(JsonFieldType.STRING)
-                            .attributes(field("constraints", "공백을 허용하지 않습니다."))
-                            .description("애피소드 화수"),
-                        fieldWithPath("year")
-                            .type(JsonFieldType.NUMBER)
-                            .attributes(field("constraints", "1900 이상의 숫자만 허용합니다."))
-                            .description("애니 발행 년도"),
-                        fieldWithPath("quarter")
-                            .type(JsonFieldType.STRING)
-                            .attributes(field("constraints", "Q1,Q2,Q3,Q4만 허용합니다."))
-                            .description("애니 발행 분기"),
-                        fieldWithPath("rating")
-                            .type(JsonFieldType.STRING)
-                            .attributes(field("constraints", "ADULT,FIFTEEN,TWELVE,ALL만 허용합니다."))
-                            .description("애니 등급"),
-                        fieldWithPath("status")
-                            .type(JsonFieldType.STRING)
-                            .attributes(field("constraints", "ONGOING,FINISHED,UPCOMING,UNKNOWN만 허용합니다."))
-                            .description("애니 상태")
-                    )
-                ));
+                    .andExpect(status().isNoContent())
+                    .andDo(document("patchAnime/success",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            pathParameters(
+                                    parameterWithName("animeId").description("애니의 식별자")
+                            ),
+                            requestFields(attributes(key("title").value("Fields for anime creation")),
+                                    fieldWithPath("title")
+                                            .type(JsonFieldType.STRING)
+                                            .attributes(field("constraints", "공백을 허용하지 않습니다. 1~50자를 허용합니다."))
+                                            .description("애니의 제목"),
+                                    fieldWithPath("summary")
+                                            .type(JsonFieldType.STRING)
+                                            .attributes(field("constraints", "공백을 허용하지 않습니다. 1~255자를 허용합니다."))
+                                            .description("애니 요약 설명"),
+                                    fieldWithPath("broadcastType")
+                                            .type(JsonFieldType.STRING)
+                                            .attributes(field("constraints", "TVA,ONA,OVA,MOV만 허용합니다."))
+                                            .description("애니 방송사"),
+                                    fieldWithPath("episodeCount")
+                                            .type(JsonFieldType.NUMBER)
+                                            .attributes(field("constraints", "0 이상의 숫자만 허용합니다."))
+                                            .description("애피소드 화수"),
+                                    fieldWithPath("thumbnail")
+                                            .type(JsonFieldType.STRING)
+                                            .attributes(field("constraints", "공백을 허용하지 않습니다."))
+                                            .description("애피소드 화수"),
+                                    fieldWithPath("year")
+                                            .type(JsonFieldType.NUMBER)
+                                            .attributes(field("constraints", "1900 이상의 숫자만 허용합니다."))
+                                            .description("애니 발행 년도"),
+                                    fieldWithPath("quarter")
+                                            .type(JsonFieldType.STRING)
+                                            .attributes(field("constraints", "Q1,Q2,Q3,Q4만 허용합니다."))
+                                            .description("애니 발행 분기"),
+                                    fieldWithPath("rating")
+                                            .type(JsonFieldType.STRING)
+                                            .attributes(field("constraints", "ADULT,FIFTEEN,TWELVE,ALL만 허용합니다."))
+                                            .description("애니 등급"),
+                                    fieldWithPath("status")
+                                            .type(JsonFieldType.STRING)
+                                            .attributes(field("constraints", "ONGOING,FINISHED,UPCOMING,UNKNOWN만 허용합니다."))
+                                            .description("애니 상태")
+                            )
+                    ));
 
         }
         //TODO: 수정 실패 시
@@ -242,28 +236,28 @@ public class AdminControllerTest {
 
             //when
             ResultActions actions = mockMvc.perform(
-                patch(ADMIN_URL+"/animes/{animeId}/original-authors", animeId)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .content(content)
+                    patch(ADMIN_URL+"/animes/{animeId}/original-authors", animeId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .content(content)
             );
 
             //then
             actions
-                .andDo(document("patchAnimeOriginalAuthors/success",
-                    preprocessRequest(prettyPrint()),
-                    preprocessResponse(prettyPrint()),
-                    pathParameters(
-                        parameterWithName("animeId").description("애니의 식별자")
-                    ),
-                    requestFields(attributes(key("title").value("Fields for anime creation")),
-                        fieldWithPath("originalAuthorIds")
-                            .type(JsonFieldType.ARRAY)
-                            .description("원작 작가들 아이디 리스트")
-                            .attributes(field("constraints", "List만 허용합니다."))
-                            .optional()
-                    )
-                ));
+                    .andDo(document("patchAnimeOriginalAuthors/success",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            pathParameters(
+                                    parameterWithName("animeId").description("애니의 식별자")
+                            ),
+                            requestFields(attributes(key("title").value("Fields for anime creation")),
+                                    fieldWithPath("originalAuthorIds")
+                                            .type(JsonFieldType.ARRAY)
+                                            .description("원작 작가들 아이디 리스트")
+                                            .attributes(field("constraints", "List만 허용합니다."))
+                                            .optional()
+                            )
+                    ));
 
         }
         //TODO: 수정 실패 시
@@ -280,28 +274,28 @@ public class AdminControllerTest {
 
             //when
             ResultActions actions = mockMvc.perform(
-                patch(ADMIN_URL+"/animes/{animeId}/studios", animeId)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .content(content)
+                    patch(ADMIN_URL+"/animes/{animeId}/studios", animeId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .content(content)
             );
 
             //then
             actions
-                .andDo(document("patchAnimeStudios/success",
-                    preprocessRequest(prettyPrint()),
-                    preprocessResponse(prettyPrint()),
-                    pathParameters(
-                        parameterWithName("animeId").description("애니의 식별자")
-                    ),
-                    requestFields(attributes(key("title").value("Fields for anime creation")),
-                        fieldWithPath("studioIds")
-                            .type(JsonFieldType.ARRAY)
-                            .description("스튜디오 아이디 리스트")
-                            .attributes(field("constraints", "List만 허용합니다."))
-                            .optional()
-                    )
-                ));
+                    .andDo(document("patchAnimeStudios/success",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            pathParameters(
+                                    parameterWithName("animeId").description("애니의 식별자")
+                            ),
+                            requestFields(attributes(key("title").value("Fields for anime creation")),
+                                    fieldWithPath("studioIds")
+                                            .type(JsonFieldType.ARRAY)
+                                            .description("스튜디오 아이디 리스트")
+                                            .attributes(field("constraints", "List만 허용합니다."))
+                                            .optional()
+                            )
+                    ));
 
         }
         //TODO: 수정 실패 시
@@ -311,43 +305,43 @@ public class AdminControllerTest {
         void patchAnimeVoiceActors() throws Exception {
             //given
             Long animeId = 1L;
-            List<VoiceActorReq> voiceActors = AnimeTestUtils.getVoiceActorReqs();
+            List<AnimeVoiceActorReq> voiceActors = AnimeTestUtils.getVoiceActorReqs();
 
             PatchVoiceActorIdsReq req = new PatchVoiceActorIdsReq(voiceActors);
             String content = gson.toJson(req);
 
             //when
             ResultActions actions = mockMvc.perform(
-                put(ADMIN_URL+"/animes/{animeId}/voice-actors", animeId)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .content(content)
+                    put(ADMIN_URL+"/animes/{animeId}/voice-actors", animeId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .content(content)
             );
 
             //then
             actions
-                .andDo(document("patchAnimeVoiceActors/success",
-                    preprocessRequest(prettyPrint()),
-                    preprocessResponse(prettyPrint()),
-                    pathParameters(
-                        parameterWithName("animeId").description("애니의 식별자")
-                    ),
-                    requestFields(attributes(key("title").value("Fields for anime creation")),
-                        fieldWithPath("voiceActors")
-                            .type(JsonFieldType.ARRAY)
-                            .description("애니 성우 리스트")
-                            .attributes(field("constraints", "List만 허용합니다."))
-                            .optional(),
-                        fieldWithPath("voiceActors[].id")
-                            .type(JsonFieldType.NUMBER)
-                            .description("성우의 아이디")
-                            .attributes(field("constraints", "숫자만 허용합니다.")),
-                        fieldWithPath("voiceActors[].part")
-                            .type(JsonFieldType.STRING)
-                            .description("성우의 역할")
-                            .attributes(field("constraints", "100자 이하만 허용합니다."))
-                    )
-                ));
+                    .andDo(document("patchAnimeVoiceActors/success",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            pathParameters(
+                                    parameterWithName("animeId").description("애니의 식별자")
+                            ),
+                            requestFields(attributes(key("title").value("Fields for anime creation")),
+                                    fieldWithPath("voiceActors")
+                                            .type(JsonFieldType.ARRAY)
+                                            .description("애니 성우 리스트")
+                                            .attributes(field("constraints", "List만 허용합니다."))
+                                            .optional(),
+                                    fieldWithPath("voiceActors[].id")
+                                            .type(JsonFieldType.NUMBER)
+                                            .description("성우의 아이디")
+                                            .attributes(field("constraints", "숫자만 허용합니다.")),
+                                    fieldWithPath("voiceActors[].part")
+                                            .type(JsonFieldType.STRING)
+                                            .description("성우의 역할")
+                                            .attributes(field("constraints", "100자 이하만 허용합니다."))
+                            )
+                    ));
         }
         //TODO: 수정 실패 시
 
@@ -363,33 +357,33 @@ public class AdminControllerTest {
 
             //when
             ResultActions actions = mockMvc.perform(
-                put(ADMIN_URL+"/animes/{animeId}/genres", animeId)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .content(content)
+                    put(ADMIN_URL+"/animes/{animeId}/genres", animeId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .content(content)
             );
 
             //then
             actions
-                .andDo(document("patchAnimeGenres/success",
-                    preprocessRequest(prettyPrint()),
-                    preprocessResponse(prettyPrint()),
-                    pathParameters(
-                        parameterWithName("animeId").description("애니의 식별자")
-                    ),
-                    requestFields(attributes(key("title").value("Fields for anime creation")),
-                        fieldWithPath("genreIds")
-                            .type(JsonFieldType.ARRAY)
-                            .description("애니 장르 아이디 리스트")
-                            .attributes(field("constraints", "List만 허용합니다."))
-                            .optional()
-                    )
-                ));
+                    .andDo(document("patchAnimeGenres/success",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            pathParameters(
+                                    parameterWithName("animeId").description("애니의 식별자")
+                            ),
+                            requestFields(attributes(key("title").value("Fields for anime creation")),
+                                    fieldWithPath("genreIds")
+                                            .type(JsonFieldType.ARRAY)
+                                            .description("애니 장르 아이디 리스트")
+                                            .attributes(field("constraints", "List만 허용합니다."))
+                                            .optional()
+                            )
+                    ));
         }
         //TODO: 수정 실패 시
 
         @Test
-        @DisplayName("애니의 시리즈 수정 성공 시 Http Status 204 반환")
+        @DisplayName("시리즈 수정 성공 시 Http Status 204 반환")
         void patchAnimeSeries() throws Exception {
             //given
             Long animeId = 1L;
@@ -398,30 +392,329 @@ public class AdminControllerTest {
 
             //when
             ResultActions actions = mockMvc.perform(
-                patch(ADMIN_URL+"/animes/{animeId}/series", animeId)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .content(content)
+                    patch(ADMIN_URL+"/animes/{animeId}/series", animeId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .content(content)
             );
 
             //then
             actions
-                .andExpect(status().isNoContent())
-                .andDo(document("patchAnimeSeries/success",
-                    preprocessRequest(prettyPrint()),
-                    preprocessResponse(prettyPrint()),
-                    pathParameters(
-                        parameterWithName("animeId").description("애니의 식별자")
-                    ),
-                    requestFields(attributes(key("title").value("Fields for anime creation")),
-                        fieldWithPath("seriesId")
-                            .type(JsonFieldType.NUMBER)
-                            .description("애니 시리즈 아이디")
-                            .attributes(field("constraints", "숫자만 허용합니다."))
-                            .optional()
-                    )
-                ));
+                    .andExpect(status().isNoContent())
+                    .andDo(document("patchAnimeSeries/success",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            pathParameters(
+                                    parameterWithName("animeId").description("애니의 식별자")
+                            ),
+                            requestFields(attributes(key("title").value("Fields for anime creation")),
+                                    fieldWithPath("seriesId")
+                                            .type(JsonFieldType.NUMBER)
+                                            .description("애니 시리즈 아이디")
+                                            .attributes(field("constraints", "숫자만 허용합니다."))
+                                            .optional()
+                            )
+                    ));
         }
         //TODO: 수정 실패 시
+
     }
+
+    @Nested
+    @DisplayName("원작 작가")
+    class OriginalAuthorTest{
+        @Test
+        @DisplayName("조회 성공 시 Http status 200 반환")
+        void getOriginalAuthors() throws Exception {
+            ResultActions actions = mockMvc.perform(
+                    RestDocumentationRequestBuilders.get(ADMIN_URL+"/original-authors")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+            );
+
+            actions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$[0].id").exists())
+                    .andExpect(jsonPath("$[0].name").exists())
+                    .andDo(document("getOriginalAuthors/success",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            responseFields(
+                        fieldWithPath("[].id")
+                                            .type(JsonFieldType.NUMBER)
+                                            .description("원작 작가의 고유 식별자"),
+                                    fieldWithPath("[].name")
+                                            .type(JsonFieldType.STRING)
+                                            .description("원작 작가의 이름")
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("등록 성공 시 Http Status 204 반환")
+        void postOriginalAuthor() throws Exception {
+            String name = "고토게 코요하루";
+            OriginalAuthorReq.PostReq postReq = new OriginalAuthorReq.PostReq(name);
+            String content = gson.toJson(postReq);
+
+            ResultActions actions = mockMvc.perform(
+                    post(ADMIN_URL + "/original-authors")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .content(content)
+            );
+
+            actions
+                    .andExpect(status().isNoContent())
+                    .andDo(document("postOriginalAuthor/success",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestFields(attributes(key("title").value("Fields for original author creation")),
+                                    fieldWithPath("name")
+                                            .type(JsonFieldType.STRING)
+                                            .attributes(field("constraints", "공백을 허용하지 않습니다. 1~50자를 허용합니다."))
+                                            .description("원작 작가의 이름")
+                            )
+                    ));
+        }
+    }
+
+    @Nested
+    @DisplayName("성우")
+    class VoiceActorTest{
+        @Test
+        @DisplayName("조회 성공 시 Http status 200 반환")
+        void getOriginalAuthors() throws Exception {
+            ResultActions actions = mockMvc.perform(
+                    RestDocumentationRequestBuilders.get(ADMIN_URL+"/voice-actors")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+            );
+
+            actions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$[0].id").exists())
+                    .andExpect(jsonPath("$[0].name").exists())
+                    .andDo(document("getVoiceActors/success",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            responseFields(
+                                    fieldWithPath("[].id")
+                                            .type(JsonFieldType.NUMBER)
+                                            .description("성우의 고유 식별자"),
+                                    fieldWithPath("[].name")
+                                            .type(JsonFieldType.STRING)
+                                            .description("성우의 이름")
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("등록 성공 시 Http Status 204 반환")
+        void postVoiceActor() throws Exception {
+            String name = "에구치 타쿠야";
+            VoiceActorReq.PostReq postReq = new VoiceActorReq.PostReq(name);
+            String content = gson.toJson(postReq);
+
+            ResultActions actions = mockMvc.perform(
+                    post(ADMIN_URL + "/voice-actors")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .content(content)
+            );
+
+            actions
+                    .andExpect(status().isNoContent())
+                    .andDo(document("postVoiceActor/success",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestFields(attributes(key("title").value("Fields for original author creation")),
+                                    fieldWithPath("name")
+                                            .type(JsonFieldType.STRING)
+                                            .attributes(field("constraints", "공백을 허용하지 않습니다. 1~50자를 허용합니다."))
+                                            .description("성우의 이름")
+                            )
+                    ));
+        }
+    }
+
+    @Nested
+    @DisplayName("스튜디오")
+    class StudioTest{
+        @Test
+        @DisplayName("조회 성공 시 Http status 200 반환")
+        void getStudios() throws Exception {
+            ResultActions actions = mockMvc.perform(
+                    RestDocumentationRequestBuilders.get(ADMIN_URL+"/studios")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+            );
+
+            actions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$[0].id").exists())
+                    .andExpect(jsonPath("$[0].name").exists())
+                    .andDo(document("getStudios/success",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            responseFields(
+                                    fieldWithPath("[].id")
+                                            .type(JsonFieldType.NUMBER)
+                                            .description("스튜디오의 고유 식별자"),
+                                    fieldWithPath("[].name")
+                                            .type(JsonFieldType.STRING)
+                                            .description("스튜디오의 이름")
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("등록 성공 시 Http Status 204 반환")
+        void postVoiceActor() throws Exception {
+            String name = "ufortable";
+            StudioReq.PostReq postReq = new StudioReq.PostReq(name);
+            String content = gson.toJson(postReq);
+
+            ResultActions actions = mockMvc.perform(
+                    post(ADMIN_URL + "/studios")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .content(content)
+            );
+
+            actions
+                    .andExpect(status().isNoContent())
+                    .andDo(document("postStudio/success",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestFields(attributes(key("title").value("Fields for original author creation")),
+                                    fieldWithPath("name")
+                                            .type(JsonFieldType.STRING)
+                                            .attributes(field("constraints", "공백을 허용하지 않습니다. 1~50자를 허용합니다."))
+                                            .description("스튜디오의 이름")
+                            )
+                    ));
+        }
+    }
+
+
+    @Nested
+    @DisplayName("장르")
+    class GenreTest{
+        @Test
+        @DisplayName("조회 성공 시 Http status 200 반환")
+        void getGenres() throws Exception {
+            ResultActions actions = mockMvc.perform(
+                    RestDocumentationRequestBuilders.get(ADMIN_URL+"/genres")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+            );
+
+            actions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$[0].id").exists())
+                    .andExpect(jsonPath("$[0].name").exists())
+                    .andDo(document("getGenres/success",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            responseFields(
+                                    fieldWithPath("[].id")
+                                            .type(JsonFieldType.NUMBER)
+                                            .description("장르의 고유 식별자"),
+                                    fieldWithPath("[].name")
+                                            .type(JsonFieldType.STRING)
+                                            .description("장르의 이름")
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("등록 성공 시 Http Status 204 반환")
+        void postVoiceActor() throws Exception {
+            String name = "판타지";
+            GenreReq.PostReq postReq = new GenreReq.PostReq(name);
+            String content = gson.toJson(postReq);
+
+            ResultActions actions = mockMvc.perform(
+                    post(ADMIN_URL + "/genres")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .content(content)
+            );
+
+            actions
+                    .andExpect(status().isNoContent())
+                    .andDo(document("postGenre/success",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestFields(attributes(key("title").value("Fields for original author creation")),
+                                    fieldWithPath("name")
+                                            .type(JsonFieldType.STRING)
+                                            .attributes(field("constraints", "공백을 허용하지 않습니다. 1~50자를 허용합니다."))
+                                            .description("장르의 이름")
+                            )
+                    ));
+        }
+    }
+
+
+    @Nested
+    @DisplayName("시리즈")
+    class SeriesTest{
+        @Test
+        @DisplayName("조회 성공 시 Http status 200 반환")
+        void getSeries() throws Exception {
+            ResultActions actions = mockMvc.perform(
+                    RestDocumentationRequestBuilders.get(ADMIN_URL+"/series")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+            );
+
+            actions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$[0].id").exists())
+                    .andExpect(jsonPath("$[0].title").exists())
+                    .andDo(document("getSeries/success",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            responseFields(
+                                    fieldWithPath("[].id")
+                                            .type(JsonFieldType.NUMBER)
+                                            .description("시리즈의 고유 식별자"),
+                                    fieldWithPath("[].title")
+                                            .type(JsonFieldType.STRING)
+                                            .description("시리즈의 제목")
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("등록 성공 시 Http Status 204 반환")
+        void postSeries() throws Exception {
+            String title = "귀멸의 칼날";
+            SeriesReq.PostReq postReq = new SeriesReq.PostReq(title);
+            String content = gson.toJson(postReq);
+
+            ResultActions actions = mockMvc.perform(
+                    post(ADMIN_URL + "/series")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .content(content)
+            );
+
+            actions
+                    .andExpect(status().isNoContent())
+                    .andDo(document("postSeries/success",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestFields(attributes(key("title").value("Fields for original author creation")),
+                                    fieldWithPath("title")
+                                            .type(JsonFieldType.STRING)
+                                            .attributes(field("constraints", "공백을 허용하지 않습니다. 1~50자를 허용합니다."))
+                                            .description("시리즈의 제목")
+                            )
+                    ));
+        }
+    }
+
 }

--- a/src/test/java/io/oduck/api/global/utils/AnimeTestUtils.java
+++ b/src/test/java/io/oduck/api/global/utils/AnimeTestUtils.java
@@ -2,7 +2,7 @@ package io.oduck.api.global.utils;
 
 import io.oduck.api.domain.anime.dto.AnimeReq.PatchAnimeReq;
 import io.oduck.api.domain.anime.dto.AnimeReq.PostReq;
-import io.oduck.api.domain.anime.dto.VoiceActorReq;
+import io.oduck.api.domain.anime.dto.AnimeVoiceActorReq;
 import io.oduck.api.domain.anime.entity.Anime;
 import io.oduck.api.domain.anime.entity.BroadcastType;
 import io.oduck.api.domain.anime.entity.Quarter;
@@ -78,10 +78,10 @@ public class AnimeTestUtils {
         return genreIds;
     }
 
-    public static List<VoiceActorReq> getVoiceActorReqs() {
-        List<VoiceActorReq> voiceActors = new ArrayList<>();
-        VoiceActorReq firstDto = new VoiceActorReq(5L, "카마도 탄지로");
-        VoiceActorReq secondDto = new VoiceActorReq(6L, "카마도 네즈코");
+    public static List<AnimeVoiceActorReq> getVoiceActorReqs() {
+        List<AnimeVoiceActorReq> voiceActors = new ArrayList<>();
+        AnimeVoiceActorReq firstDto = new AnimeVoiceActorReq(5L, "카마도 탄지로");
+        AnimeVoiceActorReq secondDto = new AnimeVoiceActorReq(6L, "카마도 네즈코");
         voiceActors.add(firstDto);
         voiceActors.add(secondDto);
         return voiceActors;

--- a/src/test/java/io/oduck/api/unit/anime/service/AnimeServiceTest.java
+++ b/src/test/java/io/oduck/api/unit/anime/service/AnimeServiceTest.java
@@ -146,6 +146,13 @@ public class AnimeServiceTest {
 
             // then
             assertThatNoException();
+
+            //verify
+            verify(originalAuthorRepository, times(1)).findAllById(anyList());
+            verify(voiceActorRepository, times(1)).findAllById(anyList());
+            verify(studioRepository, times(1)).findAllById(anyList());
+            verify(genreRepository, times(1)).findAllById(anyList());
+            verify(seriesRepository, times(1)).findById(anyLong());
         }
     }
 

--- a/src/test/java/io/oduck/api/unit/anime/service/AnimeServiceTest.java
+++ b/src/test/java/io/oduck/api/unit/anime/service/AnimeServiceTest.java
@@ -75,7 +75,7 @@ public class AnimeServiceTest {
 
     @Nested
     @DisplayName("조회")
-    class findAnime{
+    class GetAnime{
         Anime anime = createAnime();
 
         @Test

--- a/src/test/java/io/oduck/api/unit/anime/service/AnimeServiceTest.java
+++ b/src/test/java/io/oduck/api/unit/anime/service/AnimeServiceTest.java
@@ -1,7 +1,7 @@
 package io.oduck.api.unit.anime.service;
 
 import io.oduck.api.domain.anime.dto.AnimeReq.*;
-import io.oduck.api.domain.anime.dto.VoiceActorReq;
+import io.oduck.api.domain.anime.dto.AnimeVoiceActorReq;
 import io.oduck.api.domain.anime.entity.*;
 import io.oduck.api.domain.anime.repository.*;
 import io.oduck.api.domain.anime.service.AnimeServiceImpl;
@@ -230,8 +230,8 @@ public class AnimeServiceTest {
             //given
             Long animeId = 1L;
 
-            List<VoiceActorReq> patchReqs = getVoiceActorReqs();
-            List<Long> voiceActorIds = patchReqs.stream().map(VoiceActorReq::getId)
+            List<AnimeVoiceActorReq> patchReqs = getVoiceActorReqs();
+            List<Long> voiceActorIds = patchReqs.stream().map(AnimeVoiceActorReq::getId)
                 .collect(Collectors.toList());
 
             PatchVoiceActorIdsReq patchReq = new PatchVoiceActorIdsReq(patchReqs);

--- a/src/test/java/io/oduck/api/unit/genre/repository/GenreRepositoryTest.java
+++ b/src/test/java/io/oduck/api/unit/genre/repository/GenreRepositoryTest.java
@@ -1,0 +1,66 @@
+package io.oduck.api.unit.genre.repository;
+
+import io.oduck.api.domain.genre.entity.Genre;
+import io.oduck.api.domain.genre.repository.GenreRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+public class GenreRepositoryTest {
+
+    @Autowired
+    private GenreRepository genreRepository;
+
+    @Nested
+    @DisplayName("등록")
+    class SaveGenre {
+        @Test
+        @DisplayName("장르 등록 성공")
+        void saveGenre() {
+            //given
+            Genre genre = Genre.builder()
+                    .name("로맨스")
+                    .build();
+
+            //when
+            Genre savedGenre = genreRepository.save(genre);
+
+            //then
+            assertThat(genre.getId()).isEqualTo(savedGenre.getId());
+            assertThat(genre.getName()).isEqualTo(savedGenre.getName());
+        }
+    }
+
+    @Nested
+    @DisplayName("조회")
+    class FindGenre {
+        @Test
+        @DisplayName("장르 조회 성공")
+        void findGenre() {
+            //given
+            Genre genre = Genre.builder()
+                    .name("판타지")
+                    .build();
+
+            Genre savedGenre = genreRepository.save(genre);
+
+            //when
+            List<Genre> genres = genreRepository.findAll();
+
+            //then
+            assertThat(savedGenre).isIn(genres);
+
+        }
+    }
+}

--- a/src/test/java/io/oduck/api/unit/genre/service/GenreServiceTest.java
+++ b/src/test/java/io/oduck/api/unit/genre/service/GenreServiceTest.java
@@ -1,0 +1,63 @@
+package io.oduck.api.unit.genre.service;
+
+import io.oduck.api.domain.genre.dto.GenreReq;
+import io.oduck.api.domain.genre.entity.Genre;
+import io.oduck.api.domain.genre.repository.GenreRepository;
+import io.oduck.api.domain.genre.service.GenreServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class GenreServiceTest {
+
+    @InjectMocks
+    private GenreServiceImpl genreService;
+
+    @Mock
+    private GenreRepository genreRepository;
+
+    @Nested
+    @DisplayName("등록")
+    class SaveGenre {
+        @Test
+        @DisplayName("장르 등록 성공")
+        void saveVoiceActors() {
+            //given
+            GenreReq.PostReq postReq = new GenreReq.PostReq("로맨스");
+
+            //when
+            genreService.save(postReq);
+
+            //then
+            assertThatNoException();
+
+            //verify
+            verify(genreRepository, times(1)).save(any(Genre.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("조회")
+    class GetVoiceActors {
+        @Test
+        @DisplayName("장르 조회 성공")
+        void getVoiceActors() {
+            //when
+            genreService.getGenres();
+
+            //then
+            assertThatNoException();
+
+            //verify
+            verify(genreRepository, times(1)).findAll();
+        }
+    }
+}

--- a/src/test/java/io/oduck/api/unit/originalAuthor/repository/OriginalAuthorRepositoryTest.java
+++ b/src/test/java/io/oduck/api/unit/originalAuthor/repository/OriginalAuthorRepositoryTest.java
@@ -1,0 +1,66 @@
+package io.oduck.api.unit.originalAuthor.repository;
+
+import io.oduck.api.domain.originalAuthor.entity.OriginalAuthor;
+import io.oduck.api.domain.originalAuthor.repository.OriginalAuthorRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+public class OriginalAuthorRepositoryTest {
+
+    @Autowired
+    private OriginalAuthorRepository originalAuthorRepository;
+
+    @Nested
+    @DisplayName("등록")
+    class SaveOriginalAuthorTest{
+        @Test
+        @DisplayName("원작 작가 등록 성공")
+        void SaveOriginalAuthor() {
+            //given
+            OriginalAuthor originalAuthor = OriginalAuthor.builder()
+                    .name("엔도 타츠야")
+                    .build();
+
+            //when
+            OriginalAuthor savedOriginalAuthor = originalAuthorRepository.save(originalAuthor);
+
+            //then
+            assertThat(originalAuthor.getId()).isEqualTo(savedOriginalAuthor.getId());
+            assertThat(originalAuthor.getName()).isEqualTo(savedOriginalAuthor.getName());
+        }
+    }
+
+    @Nested
+    @DisplayName("조회")
+    class FindOriginalAuthor {
+        @Test
+        @DisplayName("원작 작가 조회 성공")
+        void findOriginalAuthor() {
+            //given
+            OriginalAuthor originalAuthor = OriginalAuthor.builder()
+                    .name("성우A")
+                    .build();
+
+            OriginalAuthor savedOriginalAuthor = originalAuthorRepository.save(originalAuthor);
+
+            //when
+            List<OriginalAuthor> originalAuthors = originalAuthorRepository.findAll();
+
+            //then
+            assertThat(savedOriginalAuthor).isIn(originalAuthors);
+
+        }
+    }
+}

--- a/src/test/java/io/oduck/api/unit/originalAuthor/service/OriginalAuthorServiceTest.java
+++ b/src/test/java/io/oduck/api/unit/originalAuthor/service/OriginalAuthorServiceTest.java
@@ -1,0 +1,65 @@
+package io.oduck.api.unit.originalAuthor.service;
+
+import io.oduck.api.domain.originalAuthor.dto.OriginalAuthorReq;
+import io.oduck.api.domain.originalAuthor.entity.OriginalAuthor;
+import io.oduck.api.domain.originalAuthor.repository.OriginalAuthorRepository;
+import io.oduck.api.domain.originalAuthor.service.OriginalAuthorServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class OriginalAuthorServiceTest {
+
+    @InjectMocks
+    private OriginalAuthorServiceImpl originalAuthorService;
+
+    @Mock
+    private OriginalAuthorRepository originalAuthorRepository;
+
+    @Nested
+    @DisplayName("등록")
+    class PostOriginalAuthor {
+        @Test
+        @DisplayName("원작 작가 등록 성공")
+        void postOriginalAuthor() {
+            //given
+            OriginalAuthorReq.PostReq postReq = new OriginalAuthorReq.PostReq("하나에 나츠키");
+
+            //when
+            originalAuthorService.save(postReq);
+
+            //then
+            assertThatNoException();
+
+            //verify
+            verify(originalAuthorRepository, times(1)).save(any(OriginalAuthor.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("조회")
+    class GetOriginalAuthors {
+        @Test
+        @DisplayName("원작 작가들 조회")
+        void getOriginalAuthors(){
+            //when
+            originalAuthorService.getOriginalAuthors();
+
+            //then
+            assertThatNoException();
+
+            //verify
+            verify(originalAuthorRepository, times(1)).findAll();
+        }
+    }
+}

--- a/src/test/java/io/oduck/api/unit/series/repository/SeriesRepositoryTest.java
+++ b/src/test/java/io/oduck/api/unit/series/repository/SeriesRepositoryTest.java
@@ -1,0 +1,65 @@
+package io.oduck.api.unit.series.repository;
+
+import io.oduck.api.domain.series.entity.Series;
+import io.oduck.api.domain.series.repository.SeriesRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+public class SeriesRepositoryTest {
+
+    @Autowired
+    private SeriesRepository seriesRepository;
+
+    @Nested
+    @DisplayName("등록")
+    class SaveSeries {
+        @Test
+        @DisplayName("시리즈 등록 성공")
+        void saveSeries() {
+            //given
+            Series series = Series.builder()
+                    .title("스파이 패밀리")
+                    .build();
+
+            //when
+            Series savedSeries = seriesRepository.save(series);
+
+            //then
+            assertThat(series.getId()).isEqualTo(savedSeries.getId());
+            assertThat(series.getTitle()).isEqualTo(savedSeries.getTitle());
+        }
+    }
+
+    @Nested
+    @DisplayName("조회")
+    class FindSeries {
+        @Test
+        @DisplayName("시리즈 조회 성공")
+        void findSeries() {
+            //given
+            Series series = Series.builder()
+                    .title("스파이 패밀리")
+                    .build();
+
+            Series savedSeries = seriesRepository.save(series);
+
+            //when
+            List<Series> originalAuthors = seriesRepository.findAll();
+
+            //then
+            assertThat(savedSeries).isIn(originalAuthors);
+        }
+    }
+}

--- a/src/test/java/io/oduck/api/unit/series/service/SeriesServiceTest.java
+++ b/src/test/java/io/oduck/api/unit/series/service/SeriesServiceTest.java
@@ -1,0 +1,64 @@
+package io.oduck.api.unit.series.service;
+
+import io.oduck.api.domain.series.dto.SeriesReq;
+import io.oduck.api.domain.series.entity.Series;
+import io.oduck.api.domain.series.repository.SeriesRepository;
+import io.oduck.api.domain.series.service.SeriesServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class SeriesServiceTest {
+    @InjectMocks
+    private SeriesServiceImpl seriesService;
+
+    @Mock
+    private SeriesRepository seriesRepository;
+
+    @Nested
+    @DisplayName("등록")
+    class SaveSeries {
+        @Test
+        @DisplayName("시리즈 등록 성공")
+        void saveSeriesSuccess() {
+            //given
+            SeriesReq.PostReq postReq = new SeriesReq.PostReq("스파이 패밀리");
+
+            //when
+            seriesService.save(postReq);
+
+            //then
+            assertThatNoException();
+
+            //verify
+            verify(seriesRepository, times(1)).save(any(Series.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("조회")
+    class GetSeries {
+        @Test
+        @DisplayName("시리즈 조회 성공")
+        void getSeries() {
+            //when
+            seriesService.getSeries();
+
+            //then
+            assertThatNoException();
+
+            //verify
+            verify(seriesRepository, times(1)).findAll();
+        }
+    }
+}

--- a/src/test/java/io/oduck/api/unit/studio/repository/StudioRepositoryTest.java
+++ b/src/test/java/io/oduck/api/unit/studio/repository/StudioRepositoryTest.java
@@ -1,0 +1,63 @@
+package io.oduck.api.unit.studio.repository;
+
+import io.oduck.api.domain.studio.entity.Studio;
+import io.oduck.api.domain.studio.repository.StudioRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+public class StudioRepositoryTest {
+
+    @Autowired
+    private StudioRepository studioRepository;
+
+    @Nested
+    @DisplayName("등록")
+    class SaveStudio {
+        @Test
+        @DisplayName("스튜디오 등록 성공")
+        void saveStudio() {
+            //given
+            Studio studio = Studio.builder()
+                    .name("ufortable")
+                    .build();
+
+            Studio savedStudio = studioRepository.save(studio);
+
+            assertThat(studio.getId()).isEqualTo(savedStudio.getId());
+            assertThat(studio.getName()).isEqualTo(savedStudio.getName());
+        }
+    }
+
+    @Nested
+    @DisplayName("조회")
+    class FindSeries {
+        @Test
+        @DisplayName("스튜디오 조회 성공")
+        void findSeries() {
+            //given
+            Studio studio = Studio.builder()
+                    .name("스튜디오A")
+                    .build();
+
+            Studio savedStudio = studioRepository.save(studio);
+
+            //when
+            List<Studio> studios = studioRepository.findAll();
+
+            //then
+            assertThat(savedStudio).isIn(studios);
+        }
+    }
+}

--- a/src/test/java/io/oduck/api/unit/studio/service/StudioServiceTest.java
+++ b/src/test/java/io/oduck/api/unit/studio/service/StudioServiceTest.java
@@ -1,0 +1,64 @@
+package io.oduck.api.unit.studio.service;
+
+import io.oduck.api.domain.studio.dto.StudioReq;
+import io.oduck.api.domain.studio.entity.Studio;
+import io.oduck.api.domain.studio.repository.StudioRepository;
+import io.oduck.api.domain.studio.service.StudioServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class StudioServiceTest {
+
+    @InjectMocks
+    private StudioServiceImpl studioService;
+
+    @Mock
+    private StudioRepository studioRepository;
+
+    @Nested
+    @DisplayName("등록")
+    class SaveStudio {
+
+        @Test
+        @DisplayName("스튜디오 등록 성공")
+        void saveStudio() {
+            //given
+            StudioReq.PostReq postReq = new StudioReq.PostReq("ufortable");
+
+            //when
+            studioService.save(postReq);
+
+            //then
+            assertThatNoException();
+
+            //verify
+            verify(studioRepository,times(1)).save(any(Studio.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("조회")
+    class GetStudios {
+        @Test
+        @DisplayName("스튜디오 조회 성공")
+        void getStudios() {
+            //when
+            studioService.getStudios();
+
+            //then
+            assertThatNoException();
+
+            //verify
+            verify(studioRepository, times(1)).findAll();
+        }
+    }
+}

--- a/src/test/java/io/oduck/api/unit/voiceActor/repository/VoiceActorRepositoryTest.java
+++ b/src/test/java/io/oduck/api/unit/voiceActor/repository/VoiceActorRepositoryTest.java
@@ -1,0 +1,66 @@
+package io.oduck.api.unit.voiceActor.repository;
+
+import io.oduck.api.domain.voiceActor.entity.VoiceActor;
+import io.oduck.api.domain.voiceActor.repository.VoiceActorRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+public class VoiceActorRepositoryTest {
+
+    @Autowired
+    private VoiceActorRepository voiceActorRepository;
+
+    @Nested
+    @DisplayName("등록")
+    class SaveVoiceActor {
+
+        @Test
+        @DisplayName("성우 등록 성공")
+        void saveVoiceActor() {
+            //given
+            VoiceActor voiceActor = VoiceActor.builder()
+                    .name("성우1")
+                    .build();
+
+            //when
+            VoiceActor savedVoiceActor = voiceActorRepository.save(voiceActor);
+
+            //then
+            assertThat(voiceActor.getId()).isEqualTo(savedVoiceActor.getId());
+            assertThat(voiceActor.getName()).isEqualTo(savedVoiceActor.getName());
+        }
+    }
+
+    @Nested
+    @DisplayName("조회")
+    class FindSeries {
+        @Test
+        @DisplayName("성우 조회 성공")
+        void findSeries() {
+            //given
+            VoiceActor voiceActor = VoiceActor.builder()
+                    .name("성우A")
+                    .build();
+
+            VoiceActor savedVoiceActor = voiceActorRepository.save(voiceActor);
+
+            //when
+            List<VoiceActor> voiceActors = voiceActorRepository.findAll();
+
+            //then
+            assertThat(savedVoiceActor).isIn(voiceActors);
+        }
+    }
+}

--- a/src/test/java/io/oduck/api/unit/voiceActor/service/VoiceActorServiceTest.java
+++ b/src/test/java/io/oduck/api/unit/voiceActor/service/VoiceActorServiceTest.java
@@ -1,0 +1,65 @@
+package io.oduck.api.unit.voiceActor.service;
+
+import io.oduck.api.domain.voiceActor.dto.VoiceActorReq;
+import io.oduck.api.domain.voiceActor.entity.VoiceActor;
+import io.oduck.api.domain.voiceActor.repository.VoiceActorRepository;
+import io.oduck.api.domain.voiceActor.service.VoiceActorServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class VoiceActorServiceTest {
+
+    @InjectMocks
+    private VoiceActorServiceImpl voiceActorService;
+
+    @Mock
+    private VoiceActorRepository voiceActorRepository;
+
+    @Nested
+    @DisplayName("등록")
+    class SaveVoiceActor {
+        @Test
+        @DisplayName("성우 등록 성공")
+        void saveVoiceActor() {
+            //given
+            VoiceActorReq.PostReq postReq = new VoiceActorReq.PostReq("성우1");
+
+            //when
+            voiceActorService.save(postReq);
+
+            //then
+            assertThatNoException();
+
+            //verify
+            verify(voiceActorRepository, times(1)).save(any(VoiceActor.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("조회")
+    class GetVoiceActors {
+        @Test
+        @DisplayName("성우 조회 성공")
+        void getVoiceActors() {
+            //when
+            voiceActorService.getVoiceActors();
+
+            //then
+            assertThatNoException();
+
+            //verify
+            verify(voiceActorRepository, times(1)).findAll();
+        }
+    }
+}


### PR DESCRIPTION
## 📝 개요

## 🚀 변경사항
- 애니 관련 도메인 등록 컨트롤러 구현
- 애니 관련 도메인 등록 서비스 구현
- 애니 관련 도메인 등록 리포지토리 구현
- docs 추가
- 관련 테스트 추가

## 🔗 관련 이슈
#39 