### PR TITLE
북마크 오류 긴급 수정 #45

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,10 @@ build/
 *.gz
 *.tmp
 src/main/resources/static/docs/index.html
-application-*.yml
+application-prod.yml
+application-dev.yml
+application-local.yml
+application-test.yml
 
 ### STS ###
 .apt_generated

--- a/src/main/java/io/oduck/api/domain/bookmark/service/BookmarkServiceImpl.java
+++ b/src/main/java/io/oduck/api/domain/bookmark/service/BookmarkServiceImpl.java
@@ -37,9 +37,8 @@ public class BookmarkServiceImpl implements BookmarkService {
 
     @Override
     @Transactional
-    @Lock(LockModeType.PESSIMISTIC_READ)
     public boolean toggleBookmark(Long memberId, Long animeId) {
-        Optional<Bookmark> optionalBookmark = getBookmark(27L, animeId);
+        Optional<Bookmark> optionalBookmark = getBookmark(memberId, animeId);
 
         Anime anime = animeRepository.findByIdForUpdate(animeId)
             .orElseThrow(() -> new NotFoundException("존재하지 않는 애니메이션입니다."));

--- a/src/main/resources/application-example.yml
+++ b/src/main/resources/application-example.yml
@@ -1,0 +1,97 @@
+server:
+  port: 8000
+  servlet:
+    contextPath:
+    session:
+      cookie:
+        path:
+        name:
+        domain:
+        http-only:
+        secure:
+      timeout:
+
+spring:
+  config:
+    activate:
+      on-profile:
+  h2:
+    console:
+      enabled: true
+      path: /h2
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+        default_batch_fetch_size:
+  datasource:
+    driver-class-name:
+    url:
+    username:
+    password:
+  data:
+    redis:
+      host:
+      port: 6379
+      session:
+        store-type: redis
+  security:
+    basic:
+      enabled: false
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id:
+            client-secret:
+            scope: profile, email
+            redirect-uri:
+
+          naver:
+            client-id:
+            client-secret:
+            redirect-uri:
+            authorization-grant-type:
+            scope: email
+            client-name: Naver
+
+          kakao:
+            client-id:
+            client-secret:
+            redirect-uri:
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            scope: account_email
+            client-name: Kakao
+
+        provider:
+          naver:
+            authorization_uri:
+            token_uri:
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user_name_attribute: response
+
+          kakao:
+            authorization-uri:
+            token-uri:
+            user-info-uri:
+            user-name-attribute: id
+
+logging:
+  level:
+    root: INFO
+  file:
+    path:
+    name:
+  logback:
+    rollingpolicy:
+      max-file-size:
+      max-history: 30       #default 7
+      file-name-pattern:
+
+config:
+  base:
+    url:

--- a/src/test/java/io/oduck/api/unit/bookmark/service/BookmarkServiceTest.java
+++ b/src/test/java/io/oduck/api/unit/bookmark/service/BookmarkServiceTest.java
@@ -76,7 +76,8 @@ public class BookmarkServiceTest {
         @Test
         void toggleBookmarkSaveSuccess() {
             given(memberRepository.findById(anyLong())).willReturn(Optional.of(member));
-            given(animeRepository.findById(anyLong())).willReturn(Optional.of(anime));
+            given(animeRepository.findByIdForUpdate(anyLong()))
+                .willReturn(Optional.of(anime));
             given(bookmarkRepository.findByMemberIdAndAnimeId(anyLong(), anyLong()))
                 .willReturn(Optional.empty());
             given(bookmarkRepository.save(any(Bookmark.class))).willReturn(bookmark);
@@ -92,6 +93,8 @@ public class BookmarkServiceTest {
         void toggleBookmarkDeleteSuccess() {
             given(bookmarkRepository.findByMemberIdAndAnimeId(anyLong(), anyLong()))
                 .willReturn(Optional.of(bookmark));
+            given(animeRepository.findByIdForUpdate(anyLong()))
+                .willReturn(Optional.of(anime));
             doNothing().when(bookmarkRepository).delete(any(Bookmark.class));
 
             boolean result = bookmarkService.toggleBookmark(member.getId(), anime.getId());

--- a/src/test/java/io/oduck/api/unit/member/service/MemberServiceTest.java
+++ b/src/test/java/io/oduck/api/unit/member/service/MemberServiceTest.java
@@ -134,7 +134,6 @@ public class MemberServiceTest {
 
             given(memberProfileRepository.findByMemberId(anyLong())).willReturn(Optional.ofNullable(memberProfile));
             given(memberProfileRepository.existsByName(anyString())).willReturn(false);
-            given(memberProfileRepository.save(any(MemberProfile.class))).willReturn(updatedMemberProfile);
 
             // when
             // then


### PR DESCRIPTION
## 📝 개요
북마크 오류 긴급 수정

## 🚀 변경사항
- bookmarkServiceImpl 북마크 토글 어노테이션 및 고정 memberId 제거
- 테스트 findByIdForUpdate 적용
- application-example 추가

## 🔗 관련 이슈
#45