### PR TITLE
인증 상태 조회 응답시 memberId, role 추가 #55

### DIFF
--- a/src/main/java/io/oduck/api/global/security/auth/controller/AuthController.java
+++ b/src/main/java/io/oduck/api/global/security/auth/controller/AuthController.java
@@ -39,7 +39,7 @@ public class AuthController {
         @LoginUser AuthUser user
     ) {
 
-        Status res = authService.getStatus(user.getId());
+        Status res = authService.getStatus(user);
 
         return ResponseEntity.ok(res);
     }

--- a/src/main/java/io/oduck/api/global/security/auth/dto/AuthResDto.java
+++ b/src/main/java/io/oduck/api/global/security/auth/dto/AuthResDto.java
@@ -13,6 +13,8 @@ public class AuthResDto {
     @AllArgsConstructor
     @Getter
     public static class Status {
+        private Long memberId;
+        private String role;
         private String name;
         private String description;
         private String thumbnail;

--- a/src/main/java/io/oduck/api/global/security/auth/dto/AuthResDto.java
+++ b/src/main/java/io/oduck/api/global/security/auth/dto/AuthResDto.java
@@ -1,23 +1,62 @@
 package io.oduck.api.global.security.auth.dto;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 
 public class AuthResDto {
-    @Builder
-    @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    @AllArgsConstructor
     @Getter
+    @NoArgsConstructor
     public static class Status {
         private Long memberId;
-        private String role;
         private String name;
         private String description;
         private String thumbnail;
         private Long point;
+
+        @Builder
+        public Status(Long memberId, String name, String description, String thumbnail,
+            Long point) {
+            this.memberId = memberId;
+            this.name = name;
+            this.description = description;
+            this.thumbnail = thumbnail;
+            this.point = point;
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class AdminStatus extends Status {
+        private String role;
+
+        public AdminStatus(Status status, String role) {
+            super(status.getMemberId(), status.getName(), status.getDescription(), status.getThumbnail(), status.getPoint());
+            this.role = role;
+        }
+
+        public static AdminStatusBuilder builder() {
+            return new AdminStatusBuilder();
+        }
+
+        public static class AdminStatusBuilder extends StatusBuilder {
+            private Status status;
+            private String role;
+
+            public AdminStatusBuilder status(Status status) {
+                this.status = status;
+                return this;
+            }
+
+            public AdminStatusBuilder role(String role) {
+                this.role = role;
+                return this;
+            }
+
+            public AdminStatus build() {
+                return new AdminStatus(status, role);
+            }
+        }
     }
 }

--- a/src/main/java/io/oduck/api/global/security/auth/dto/AuthUser.java
+++ b/src/main/java/io/oduck/api/global/security/auth/dto/AuthUser.java
@@ -2,15 +2,18 @@ package io.oduck.api.global.security.auth.dto;
 
 import io.oduck.api.domain.member.entity.LoginType;
 import java.io.Serializable;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
+@AllArgsConstructor
 public class AuthUser implements Serializable {
     private Long id;
+    private String role;
     private LoginType loginType;
 
-    @Builder
     public AuthUser(Long id, LoginType loginType) {
         this.id = id;
         this.loginType = loginType;

--- a/src/main/java/io/oduck/api/global/security/auth/service/AuthService.java
+++ b/src/main/java/io/oduck/api/global/security/auth/service/AuthService.java
@@ -29,11 +29,13 @@ public class AuthService {
     private final MemberProfileRepository memberProfileRepository;
     private final HttpSession httpSession;
 
-    public Status getStatus(Long memberId) {
-        MemberProfile memberProfile = memberProfileRepository.findByMemberId(memberId)
+    public Status getStatus(AuthUser user) {
+        MemberProfile memberProfile = memberProfileRepository.findByMemberId(user.getId())
             .orElseThrow(() -> new UnauthorizedException("UnAuthorized"));
 
         return Status.builder()
+            .memberId(user.getId())
+            .role(user.getRole())
             .name(memberProfile.getName())
             .description(memberProfile.getInfo())
             .thumbnail(memberProfile.getThumbnail())

--- a/src/main/java/io/oduck/api/global/security/auth/service/AuthService.java
+++ b/src/main/java/io/oduck/api/global/security/auth/service/AuthService.java
@@ -5,6 +5,7 @@ import io.oduck.api.domain.member.entity.MemberProfile;
 import io.oduck.api.domain.member.entity.Role;
 import io.oduck.api.domain.member.repository.MemberProfileRepository;
 import io.oduck.api.global.exception.UnauthorizedException;
+import io.oduck.api.global.security.auth.dto.AuthResDto.AdminStatus;
 import io.oduck.api.global.security.auth.dto.AuthResDto.Status;
 import io.oduck.api.global.security.auth.dto.AuthUser;
 import io.oduck.api.global.security.auth.dto.LocalAuthDto;
@@ -33,14 +34,22 @@ public class AuthService {
         MemberProfile memberProfile = memberProfileRepository.findByMemberId(user.getId())
             .orElseThrow(() -> new UnauthorizedException("UnAuthorized"));
 
-        return Status.builder()
+        Status status = Status.builder()
             .memberId(user.getId())
-            .role(user.getRole())
             .name(memberProfile.getName())
             .description(memberProfile.getInfo())
             .thumbnail(memberProfile.getThumbnail())
             .point(memberProfile.getPoint())
             .build();
+
+        if (user.getRole().equals("ADMIN")) {
+            status = AdminStatus.builder()
+                .status(status)
+                .role(user.getRole())
+                .build();
+        }
+
+        return status;
     }
 
     public AuthLocal getAuthLocal(String email) {

--- a/src/main/java/io/oduck/api/global/security/auth/service/LocalLoginService.java
+++ b/src/main/java/io/oduck/api/global/security/auth/service/LocalLoginService.java
@@ -21,7 +21,7 @@ public class LocalLoginService implements UserDetailsService {
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         Optional<AuthLocal> optionalAuthLocal = authLocalRepository.findByEmail(email);
 
-        if (!optionalAuthLocal.isPresent()) {
+        if (optionalAuthLocal.isEmpty()) {
             throw new UnauthorizedException("Unauthorized");
         }
 

--- a/src/main/java/io/oduck/api/global/security/resolver/LoginUserArgumentResolver.java
+++ b/src/main/java/io/oduck/api/global/security/resolver/LoginUserArgumentResolver.java
@@ -58,6 +58,8 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
             .id(
                 ((CustomOAuth2User)principal).getId()
             )
+            .role(
+                ((CustomOAuth2User)principal).getAuthorities().stream().findFirst().get().getAuthority().toUpperCase())
             .loginType(
                 ((CustomOAuth2User)principal).getLoginType()
             )
@@ -68,6 +70,9 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
         return AuthUser.builder()
             .id(
                 ((CustomUserDetails)principal).getId()
+            )
+            .role(
+                ((CustomUserDetails)principal).getAuthorities().stream().findFirst().get().getAuthority().toUpperCase()
             )
             .loginType(
                 ((CustomUserDetails)principal).getLoginType()

--- a/src/test/java/io/oduck/api/e2e/auth/AuthControllerTest.java
+++ b/src/test/java/io/oduck/api/e2e/auth/AuthControllerTest.java
@@ -124,6 +124,8 @@ public class AuthControllerTest {
             // then
             actions
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.memberId").exists())
+                .andExpect(jsonPath("$.role").exists())
                 .andExpect(jsonPath("$.name").exists())
                 .andExpect(jsonPath("$.description").exists())
                 .andExpect(jsonPath("$.thumbnail").exists())
@@ -138,6 +140,12 @@ public class AuthControllerTest {
                                 .description("Header Cookie, 세션 쿠키")
                         ),
                         responseFields(
+                            fieldWithPath("memberId")
+                                .type(JsonFieldType.NUMBER)
+                                .description("회원 식별자"),
+                            fieldWithPath("role")
+                                .type(JsonFieldType.STRING)
+                                .description("회원 권한"),
                             fieldWithPath("name")
                                 .type(JsonFieldType.STRING)
                                 .description("회원 이름"),


### PR DESCRIPTION
## 📝 개요
인증 상태 조회 응답시 memberId, role 추가

## 🚀 변경사항
1. 인증 상태 조회 dto 필드 추가
2. AuthUser 권한 필드 추가
3. 위에 맞춰 컨트롤러 및 서비스 수정
4. 인증 상태 조회 테스트 응답 필드 추가
5. 회원 권한에 따른 인증 상태 dto 변경

## 🔗 관련 이슈
#55 