### PR TITLE
별점 작성 추가하기 #65

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -711,3 +711,31 @@ include::{snippets}/postSeries/success/request-fields.adoc[]
 include::{snippets}/postSeries/success/http-response.adoc[]
 
 ==== 실패 시
+
+== starRating
+=== POST api/v1/ratings
+.curl-request
+include::{snippets}/starRating/createScore/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/starRating/createScore/success/http-request.adoc[]
+
+.path-parameters
+include::{snippets}/starRating/createScore/success/path-parameters.adoc[]
+
+.request-header
+include::{snippets}/starRating/createScore/success/request-headers.adoc[]
+
+.request-body
+include::{snippets}/starRating/createScore/success/request-body.adoc[]
+
+.request-fields
+include::{snippets}/starRating/createScore/success/request-fields.adoc[]
+
+==== 성공시
+.http-response
+include::{snippets}/starRating/createScore/success/http-response.adoc[]
+
+==== 실패시
+.http-response
+include::{snippets}/starRating/createScore/failure/http-response.adoc[]

--- a/src/main/java/io/oduck/api/domain/starRating/controller/StarRatingController.java
+++ b/src/main/java/io/oduck/api/domain/starRating/controller/StarRatingController.java
@@ -1,0 +1,36 @@
+package io.oduck.api.domain.starRating.controller;
+
+import io.oduck.api.domain.starRating.dto.StarRatingReqDto.CreateReq;
+import io.oduck.api.domain.starRating.service.StarRatingService;
+import io.oduck.api.global.security.auth.dto.AuthUser;
+import io.oduck.api.global.security.auth.dto.LoginUser;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RequestMapping("/ratings")
+@RequiredArgsConstructor
+@RestController
+public class StarRatingController {
+    private final StarRatingService starRatingService;
+
+    @PostMapping("/{animeId}")
+    public ResponseEntity<?> PostScore(
+        @PathVariable("animeId") @Positive Long animeId,
+        @RequestBody @Valid CreateReq body,
+        @LoginUser AuthUser user
+    ) {
+        boolean res = starRatingService.createScore(user.getId(), animeId, body.getScore());
+        return ResponseEntity.status(res ? HttpStatus.CREATED : HttpStatus.CONFLICT).build();
+    }
+
+}

--- a/src/main/java/io/oduck/api/domain/starRating/dto/StarRatingReqDto.java
+++ b/src/main/java/io/oduck/api/domain/starRating/dto/StarRatingReqDto.java
@@ -1,0 +1,21 @@
+package io.oduck.api.domain.starRating.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class StarRatingReqDto {
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreateReq {
+        @Min(value = 1, message = "score must be greater than or equal to 1")
+        @Max(value = 10, message = "score must be less than or equal to 10")
+        private int score;
+    }
+
+}

--- a/src/main/java/io/oduck/api/domain/starRating/repository/StarRatingRepository.java
+++ b/src/main/java/io/oduck/api/domain/starRating/repository/StarRatingRepository.java
@@ -1,8 +1,9 @@
 package io.oduck.api.domain.starRating.repository;
 
 import io.oduck.api.domain.starRating.entity.StarRating;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StarRatingRepository extends JpaRepository<StarRating, Long> {
-
+    Optional<StarRating> findByMemberIdAndAnimeId(Long memberId, Long animeId);
 }

--- a/src/main/java/io/oduck/api/domain/starRating/service/StarRatingService.java
+++ b/src/main/java/io/oduck/api/domain/starRating/service/StarRatingService.java
@@ -1,0 +1,5 @@
+package io.oduck.api.domain.starRating.service;
+
+public interface StarRatingService {
+    boolean createScore(Long memberId, Long animeId, int score);
+}

--- a/src/main/java/io/oduck/api/domain/starRating/service/StarRatingServiceImpl.java
+++ b/src/main/java/io/oduck/api/domain/starRating/service/StarRatingServiceImpl.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
@@ -21,6 +22,7 @@ public class StarRatingServiceImpl implements StarRatingService {
     private final StarRatingRepository starRatingRepository;
 
     @Override
+    @Transactional
     public boolean createScore(Long memberId, Long animeId, int score) {
         Optional<StarRating> foundStarRating = starRatingRepository.findByMemberIdAndAnimeId(memberId, animeId);
         if (foundStarRating.isPresent()) {
@@ -32,6 +34,8 @@ public class StarRatingServiceImpl implements StarRatingService {
 
         Anime anime = animeRepository.findById(animeId)
             .orElseThrow(() -> new NotFoundException("Anime"));
+
+        anime.increaseStarRatingScore(score);
 
         StarRating starRating = StarRating.builder()
             .member(member)

--- a/src/main/java/io/oduck/api/domain/starRating/service/StarRatingServiceImpl.java
+++ b/src/main/java/io/oduck/api/domain/starRating/service/StarRatingServiceImpl.java
@@ -1,0 +1,45 @@
+package io.oduck.api.domain.starRating.service;
+
+import io.oduck.api.domain.anime.entity.Anime;
+import io.oduck.api.domain.anime.repository.AnimeRepository;
+import io.oduck.api.domain.member.entity.Member;
+import io.oduck.api.domain.member.repository.MemberRepository;
+import io.oduck.api.domain.starRating.entity.StarRating;
+import io.oduck.api.domain.starRating.repository.StarRatingRepository;
+import io.oduck.api.global.exception.NotFoundException;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class StarRatingServiceImpl implements StarRatingService {
+    private final MemberRepository memberRepository;
+    private final AnimeRepository animeRepository;
+    private final StarRatingRepository starRatingRepository;
+
+    @Override
+    public boolean createScore(Long memberId, Long animeId, int score) {
+        Optional<StarRating> foundStarRating = starRatingRepository.findByMemberIdAndAnimeId(memberId, animeId);
+        if (foundStarRating.isPresent()) {
+            return false;
+        }
+
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new NotFoundException("Member"));
+
+        Anime anime = animeRepository.findById(animeId)
+            .orElseThrow(() -> new NotFoundException("Anime"));
+
+        StarRating starRating = StarRating.builder()
+            .member(member)
+            .anime(anime)
+            .score(score)
+            .build();
+
+        starRatingRepository.save(starRating);
+        return true;
+    }
+}

--- a/src/main/java/io/oduck/api/global/security/auth/controller/AuthController.java
+++ b/src/main/java/io/oduck/api/global/security/auth/controller/AuthController.java
@@ -1,12 +1,10 @@
 package io.oduck.api.global.security.auth.controller;
 
-import io.oduck.api.global.common.SingleResponse;
 import io.oduck.api.global.security.auth.dto.AuthResDto.Status;
 import io.oduck.api.global.security.auth.dto.LocalAuthDto;
 import io.oduck.api.global.security.auth.dto.AuthUser;
 import io.oduck.api.global.security.auth.dto.LoginUser;
 import io.oduck.api.global.security.auth.service.AuthService;
-import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
@@ -29,7 +27,6 @@ public class AuthController {
     public ResponseEntity<?> login(
         @RequestBody LocalAuthDto localAuthDto
     ) {
-
         authService.login(localAuthDto);
         return ResponseEntity.created(null).build();
     }
@@ -38,9 +35,7 @@ public class AuthController {
     public ResponseEntity<Status> status(
         @LoginUser AuthUser user
     ) {
-
         Status res = authService.getStatus(user);
-
         return ResponseEntity.ok(res);
     }
 }

--- a/src/test/java/io/oduck/api/e2e/starRating/StarRatingControllerTest.java
+++ b/src/test/java/io/oduck/api/e2e/starRating/StarRatingControllerTest.java
@@ -19,7 +19,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.google.gson.Gson;
 import io.oduck.api.domain.member.entity.Role;
 import io.oduck.api.domain.starRating.dto.StarRatingReqDto.CreateReq;
-import io.oduck.api.domain.starRating.entity.StarRating;
 import io.oduck.api.global.mockMember.WithCustomMockMember;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -132,7 +131,7 @@ public class StarRatingControllerTest {
             // then
             actions
                 .andExpect(status().isConflict())
-                .andDo(document("starRating/createScore/faile",
+                .andDo(document("starRating/createScore/failure",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         pathParameters(

--- a/src/test/java/io/oduck/api/e2e/starRating/StarRatingControllerTest.java
+++ b/src/test/java/io/oduck/api/e2e/starRating/StarRatingControllerTest.java
@@ -1,0 +1,160 @@
+package io.oduck.api.e2e.starRating;
+
+import static io.oduck.api.global.config.RestDocsConfig.field;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.snippet.Attributes.attributes;
+import static org.springframework.restdocs.snippet.Attributes.key;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.google.gson.Gson;
+import io.oduck.api.domain.member.entity.Role;
+import io.oduck.api.domain.starRating.dto.StarRatingReqDto.CreateReq;
+import io.oduck.api.domain.starRating.entity.StarRating;
+import io.oduck.api.global.mockMember.WithCustomMockMember;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc
+@ExtendWith({ RestDocumentationExtension.class, SpringExtension.class })
+@SpringBootTest
+@ActiveProfiles("test")
+public class StarRatingControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private Gson gson;
+
+    private final String BASE_URL = "/ratings";
+
+    @Nested
+    @DisplayName("POST /ratings/{animeId}")
+    class PostScore {
+        @Test
+        @DisplayName("중복된 평점이 없을 때 평점을 등록하면 201 Created를 반환")
+        @WithCustomMockMember(id = 2L, email = "john", password = "Qwer!234", role = Role.MEMBER)
+        void createScore() throws Exception {
+            // given
+            Long animeId = 2L;
+            int score = 5;
+
+            CreateReq body = CreateReq.builder()
+                .score(score)
+                .build();
+
+            String content = gson.toJson(body);
+
+            // when
+            ResultActions actions = mockMvc.perform(
+                post(BASE_URL + "/{animeId}", animeId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.COOKIE, "oDuckio.sid={SESSION_VALUE}")
+                    .content(content)
+            );
+
+            // then
+            actions
+                .andExpect(status().isCreated())
+                .andDo(document("starRating/createScore/success",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                            parameterWithName("animeId")
+                                .description("애니메이션 식별자")
+                        ),
+                        requestHeaders(
+                            headerWithName(HttpHeaders.COOKIE)
+                                .attributes(field("constraints", "oDuckio.sid={SESSION_VALUE}"))
+                                .optional()
+                                .description("Header Cookie, 세션 쿠키")
+                        ),
+                        requestFields(
+                            attributes(key("title")
+                                .value("Fields for starRating creation")),
+                            fieldWithPath("score")
+                                .type(JsonFieldType.NUMBER)
+                                .attributes(field("constraints", "1~10 사이의 정수"))
+                                .description("애니메 별점")
+                        )
+                    )
+                );
+        }
+
+        @Test
+        @DisplayName("중복된 평점이 있을 때 평점을 등록하면 209 Conflict 반환")
+        @WithCustomMockMember(id = 2L, email = "john", password = "Qwer!234", role = Role.MEMBER)
+        void createScoreIfAlreadyExist() throws Exception {
+            // given
+            Long animeId = 1L;
+            int score = 5;
+
+            CreateReq body = CreateReq.builder()
+                .score(score)
+                .build();
+
+            String content = gson.toJson(body);
+
+            // when
+            ResultActions actions = mockMvc.perform(
+                post(BASE_URL + "/{animeId}", animeId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.COOKIE, "oDuckio.sid={SESSION_VALUE}")
+                    .content(content)
+            );
+
+            // then
+            actions
+                .andExpect(status().isConflict())
+                .andDo(document("starRating/createScore/faile",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                            parameterWithName("animeId")
+                                .description("애니메이션 식별자")
+                        ),
+                        requestHeaders(
+                            headerWithName(HttpHeaders.COOKIE)
+                                .attributes(field("constraints", "oDuckio.sid={SESSION_VALUE}"))
+                                .optional()
+                                .description("Header Cookie, 세션 쿠키")
+                        ),
+                        requestFields(
+                            attributes(key("title")
+                                .value("Fields for starRating creation")),
+                            fieldWithPath("score")
+                                .type(JsonFieldType.NUMBER)
+                                .attributes(field("constraints", "1~10 사이의 정수"))
+                                .description("애니메 별점")
+                        )
+                    )
+                );
+        }
+    }
+}

--- a/src/test/java/io/oduck/api/unit/starRating/repository/StarRatingRepositoryTest.java
+++ b/src/test/java/io/oduck/api/unit/starRating/repository/StarRatingRepositoryTest.java
@@ -1,0 +1,57 @@
+package io.oduck.api.unit.starRating.repository;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import io.oduck.api.domain.starRating.entity.StarRating;
+import io.oduck.api.domain.starRating.repository.StarRatingRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@TestInstance(Lifecycle.PER_CLASS)
+@ActiveProfiles("test")
+public class StarRatingRepositoryTest {
+    @Autowired
+    StarRatingRepository starRatingRepository;
+
+    @Nested
+    @DisplayName("회원 및 애니메 식별자로 별점 조회")
+    class FindByMemberIdAndAnimeId {
+        @DisplayName("회원 및 애니메이션 식별자로 별점 조회 성공")
+        @Test
+        void findByMemberIdAndAnimeIdSuccess() {
+            // given
+            Long memberId = 1L;
+            Long animeId = 1L;
+
+            // when
+            Optional<StarRating> result = starRatingRepository.findByMemberIdAndAnimeId(memberId, animeId);
+
+            // then
+            assertNotNull(result.get());
+        }
+
+        @DisplayName("회원 및 애니메이션 식별자로 별점 조회 실패")
+        @Test
+        void findByMemberIdAndAnimeIdFailure() {
+            // given
+            Long memberId = 1L;
+            Long animeId = 10L;
+
+            // when
+            Optional<StarRating> result = starRatingRepository.findByMemberIdAndAnimeId(memberId, animeId);
+
+            // then
+            assertFalse(result.isPresent());
+        }
+    }
+}

--- a/src/test/java/io/oduck/api/unit/starRating/service/StarRatingServiceTest.java
+++ b/src/test/java/io/oduck/api/unit/starRating/service/StarRatingServiceTest.java
@@ -1,0 +1,93 @@
+package io.oduck.api.unit.starRating.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
+
+import io.oduck.api.domain.anime.entity.Anime;
+import io.oduck.api.domain.anime.repository.AnimeRepository;
+import io.oduck.api.domain.member.entity.Member;
+import io.oduck.api.domain.member.repository.MemberRepository;
+import io.oduck.api.domain.starRating.entity.StarRating;
+import io.oduck.api.domain.starRating.repository.StarRatingRepository;
+import io.oduck.api.domain.starRating.service.StarRatingServiceImpl;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class StarRatingServiceTest {
+    @InjectMocks
+    StarRatingServiceImpl starRatingService;
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @Mock
+    AnimeRepository animeRepository;
+
+    @Mock
+    StarRatingRepository starRatingRepository;
+
+    @Nested
+    @DisplayName("별점 생성")
+    class CreateScore {
+        Long memberId = 1L;
+        Long animeId = 1L;
+        int score = 5;
+
+        Member member = Member.builder()
+            .id(memberId)
+            .build();
+        Anime anime = Anime.builder()
+            .id(animeId)
+            .build();
+
+        @Test
+        @DisplayName("별점 생성 성공")
+        void createScore() {
+            // given
+            given(starRatingRepository.findByMemberIdAndAnimeId(memberId, animeId))
+                .willReturn(Optional.empty());
+            given(memberRepository.findById(memberId))
+                .willReturn(Optional.ofNullable(member));
+            given(animeRepository.findById(animeId))
+                .willReturn(Optional.ofNullable(anime));
+
+            // when
+            boolean result = starRatingService.createScore(memberId, animeId, score);
+
+            // then
+            assertDoesNotThrow(() -> starRatingService.createScore(memberId, animeId, score));
+            assertTrue(result);
+        }
+
+        @Test
+        @DisplayName("별점 생성 실패")
+        void createScoreIfAlreadyExist() {
+            // given
+
+            StarRating starRating = StarRating.builder()
+                .member(member)
+                .anime(anime)
+                .score(score)
+                .build();
+
+            given(starRatingRepository.findByMemberIdAndAnimeId(memberId, animeId))
+                .willReturn(Optional.ofNullable(starRating));
+
+            // when
+            boolean result = starRatingService.createScore(memberId, animeId, score);
+
+            // then
+            assertDoesNotThrow(() -> starRatingService.createScore(memberId, animeId, score));
+            assertFalse(result);
+        }
+    }
+}


### PR DESCRIPTION
## 📝 개요
별점 작성 추가하기

## 🚀 변경사항
1. 별점 요청 dto 생성
2. 별점 controller 및 별점 생성 핸들러 추가 
3. 별점 서비스 및 별점 생성 메소드 추가
4. 별점 repository 메소드 추가
5. 각 테스트 추가
6. 별점 생성 api 문서 추가

## 🔗 관련 이슈
#65
