### PR TITLE
애니 관련 도메인 중복 금지 로직 추가 #71

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -551,7 +551,9 @@ include::{snippets}/postOriginalAuthor/success/request-fields.adoc[]
 .http-response
 include::{snippets}/postOriginalAuthor/success/http-response.adoc[]
 
-==== 실패 시
+==== 실패 시(이름 중복)
+.http-response
+include::{snippets}/postOriginalAuthor/fail/http-response.adoc[]
 
 === GET api/v1/oduckdmin/voice-actors
 
@@ -571,7 +573,7 @@ include::{snippets}/getVoiceActors/success/response-body.adoc[]
 .response-fields
 include::{snippets}/getVoiceActors/success/response-fields.adoc[]
 
-==== 실패 시
+==== 실패 시(이름 중복)
 
 === POST api/v1/oduckdmin/voice-actors
 .curl-request
@@ -590,7 +592,9 @@ include::{snippets}/postVoiceActor/success/request-fields.adoc[]
 .http-response
 include::{snippets}/postVoiceActor/success/http-response.adoc[]
 
-==== 실패 시
+==== 실패 시(이름 중복)
+.http-response
+include::{snippets}/postVoiceActor/fail/http-response.adoc[]
 
 === GET api/v1/oduckdmin/studios
 
@@ -629,7 +633,9 @@ include::{snippets}/postStudio/success/request-fields.adoc[]
 .http-response
 include::{snippets}/postStudio/success/http-response.adoc[]
 
-==== 실패 시
+==== 실패 시 (이름 중복)
+.http-response
+include::{snippets}/postStudio/fail/http-response.adoc[]
 
 === GET api/v1/oduckdmin/genres
 
@@ -668,12 +674,14 @@ include::{snippets}/postGenre/success/request-fields.adoc[]
 .http-response
 include::{snippets}/postGenre/success/http-response.adoc[]
 
-==== 실패 시
+==== 실패 시 (이름 중복)
+.http-response
+include::{snippets}/postGenre/fail/http-response.adoc[]
 
 === GET api/v1/oduckdmin/series
 
 .curl-request
-include::{snippets}/getSeries//success/curl-request.adoc[]
+include::{snippets}/getSeries/success/curl-request.adoc[]
 
 .http-request
 include::{snippets}/getSeries/success/http-request.adoc[]
@@ -690,7 +698,7 @@ include::{snippets}/getSeries/success/response-fields.adoc[]
 
 ==== 실패 시
 
-=== POST api/v1/oduckdmin/genres
+=== POST api/v1/oduckdmin/series
 .curl-request
 include::{snippets}/postSeries/success/curl-request.adoc[]
 
@@ -707,4 +715,6 @@ include::{snippets}/postSeries/success/request-fields.adoc[]
 .http-response
 include::{snippets}/postSeries/success/http-response.adoc[]
 
-==== 실패 시
+==== 실패 시 (이름 중복)
+.http-response
+include::{snippets}/postSeries/fail/http-response.adoc[]

--- a/src/main/java/io/oduck/api/domain/genre/entity/Genre.java
+++ b/src/main/java/io/oduck/api/domain/genre/entity/Genre.java
@@ -21,6 +21,6 @@ public class Genre extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(nullable = false, length = 15)
+  @Column(nullable = false, length = 15, unique = true)
   private String name;
 }

--- a/src/main/java/io/oduck/api/domain/genre/repository/GenreRepository.java
+++ b/src/main/java/io/oduck/api/domain/genre/repository/GenreRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GenreRepository extends JpaRepository<Genre, Long> {
 
+  boolean existsByName(String name);
 }

--- a/src/main/java/io/oduck/api/domain/genre/service/GenreServiceImpl.java
+++ b/src/main/java/io/oduck/api/domain/genre/service/GenreServiceImpl.java
@@ -1,17 +1,17 @@
 package io.oduck.api.domain.genre.service;
 
+import static io.oduck.api.domain.genre.dto.GenreReq.PostReq;
+
 import io.oduck.api.domain.genre.dto.GenreRes;
 import io.oduck.api.domain.genre.entity.Genre;
 import io.oduck.api.domain.genre.repository.GenreRepository;
+import io.oduck.api.global.exception.ConflictException;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static io.oduck.api.domain.genre.dto.GenreReq.PostReq;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +23,14 @@ public class GenreServiceImpl implements GenreService{
 
     @Override
     public void save(PostReq req) {
+        String name = req.getName();
+
+        boolean isExistsName = genreRepository.existsByName(name);
+
+        if(isExistsName == true){
+            throw new ConflictException("Genre name is ");
+        }
+
         Genre genre = Genre.builder()
                 .name(req.getName())
                 .build();

--- a/src/main/java/io/oduck/api/domain/originalAuthor/entity/OriginalAuthor.java
+++ b/src/main/java/io/oduck/api/domain/originalAuthor/entity/OriginalAuthor.java
@@ -21,6 +21,6 @@ public class OriginalAuthor extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(nullable = false, length = 50)
+  @Column(nullable = false, length = 50, unique = true)
   private String name;
 }

--- a/src/main/java/io/oduck/api/domain/originalAuthor/repository/OriginalAuthorRepository.java
+++ b/src/main/java/io/oduck/api/domain/originalAuthor/repository/OriginalAuthorRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OriginalAuthorRepository extends JpaRepository<OriginalAuthor, Long> {
 
+  boolean existsByName(String name);
 }

--- a/src/main/java/io/oduck/api/domain/originalAuthor/service/OriginalAuthorServiceImpl.java
+++ b/src/main/java/io/oduck/api/domain/originalAuthor/service/OriginalAuthorServiceImpl.java
@@ -1,17 +1,17 @@
 package io.oduck.api.domain.originalAuthor.service;
 
+import static io.oduck.api.domain.originalAuthor.dto.OriginalAuthorReq.PostReq;
+
 import io.oduck.api.domain.originalAuthor.dto.OriginalAuthorRes;
 import io.oduck.api.domain.originalAuthor.entity.OriginalAuthor;
 import io.oduck.api.domain.originalAuthor.repository.OriginalAuthorRepository;
+import io.oduck.api.global.exception.ConflictException;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static io.oduck.api.domain.originalAuthor.dto.OriginalAuthorReq.PostReq;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +23,13 @@ public class OriginalAuthorServiceImpl implements OriginalAuthorService{
 
     @Override
     public void save(PostReq req) {
+        String name = req.getName();
+
+        boolean isExistsName = originalAuthorRepository.existsByName(name);
+
+        if(isExistsName == true){
+            throw new ConflictException("Original Author name");
+        }
 
         OriginalAuthor originalAuthor = OriginalAuthor.builder()
                 .name(req.getName())

--- a/src/main/java/io/oduck/api/domain/series/entity/Series.java
+++ b/src/main/java/io/oduck/api/domain/series/entity/Series.java
@@ -21,6 +21,6 @@ public class Series extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(nullable = false, length = 50)
+  @Column(nullable = false, length = 50, unique = true)
   private String title;
 }

--- a/src/main/java/io/oduck/api/domain/series/repository/SeriesRepository.java
+++ b/src/main/java/io/oduck/api/domain/series/repository/SeriesRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SeriesRepository extends JpaRepository<Series, Long> {
 
+  boolean existsByTitle(String title);
 }

--- a/src/main/java/io/oduck/api/domain/series/service/SeriesServiceImpl.java
+++ b/src/main/java/io/oduck/api/domain/series/service/SeriesServiceImpl.java
@@ -1,17 +1,17 @@
 package io.oduck.api.domain.series.service;
 
+import static io.oduck.api.domain.series.dto.SeriesReq.PostReq;
+
 import io.oduck.api.domain.series.dto.SeriesRes;
 import io.oduck.api.domain.series.entity.Series;
 import io.oduck.api.domain.series.repository.SeriesRepository;
+import io.oduck.api.global.exception.ConflictException;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static io.oduck.api.domain.series.dto.SeriesReq.PostReq;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +23,14 @@ public class SeriesServiceImpl implements SeriesService{
 
     @Override
     public void save(PostReq req) {
+        String title = req.getTitle();
+
+        boolean isExistsTitle = seriesRepository.existsByTitle(title);
+
+        if(isExistsTitle == true){
+            throw new ConflictException("Series Title");
+        }
+
         Series series = Series.builder()
                 .title(req.getTitle())
                 .build();

--- a/src/main/java/io/oduck/api/domain/studio/entity/Studio.java
+++ b/src/main/java/io/oduck/api/domain/studio/entity/Studio.java
@@ -21,6 +21,6 @@ public class Studio extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(nullable = false, length = 50)
+  @Column(nullable = false, length = 50, unique = true)
   private String name;
 }

--- a/src/main/java/io/oduck/api/domain/studio/repository/StudioRepository.java
+++ b/src/main/java/io/oduck/api/domain/studio/repository/StudioRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StudioRepository extends JpaRepository<Studio, Long> {
 
+  boolean existsByName(String name);
 }

--- a/src/main/java/io/oduck/api/domain/studio/service/StudioServiceImpl.java
+++ b/src/main/java/io/oduck/api/domain/studio/service/StudioServiceImpl.java
@@ -4,13 +4,13 @@ import io.oduck.api.domain.studio.dto.StudioReq;
 import io.oduck.api.domain.studio.dto.StudioRes;
 import io.oduck.api.domain.studio.entity.Studio;
 import io.oduck.api.domain.studio.repository.StudioRepository;
+import io.oduck.api.global.exception.ConflictException;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +22,14 @@ public class StudioServiceImpl implements StudioService{
 
     @Override
     public void save(StudioReq.PostReq req) {
+        String name = req.getName();
+
+        boolean isExistsName = studioRepository.existsByName(name);
+
+        if(isExistsName == true){
+            throw new ConflictException("Studio name");
+        }
+
         Studio studio = Studio.builder()
                 .name(req.getName())
                 .build();

--- a/src/main/java/io/oduck/api/domain/voiceActor/entity/VoiceActor.java
+++ b/src/main/java/io/oduck/api/domain/voiceActor/entity/VoiceActor.java
@@ -21,6 +21,6 @@ public class VoiceActor extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(nullable = false, length = 50)
+  @Column(nullable = false, length = 50, unique = true)
   private String name;
 }

--- a/src/main/java/io/oduck/api/domain/voiceActor/repository/VoiceActorRepository.java
+++ b/src/main/java/io/oduck/api/domain/voiceActor/repository/VoiceActorRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface VoiceActorRepository extends JpaRepository<VoiceActor, Long> {
 
+  boolean existsByName(String name);
 }

--- a/src/main/java/io/oduck/api/domain/voiceActor/service/VoiceActorServiceImpl.java
+++ b/src/main/java/io/oduck/api/domain/voiceActor/service/VoiceActorServiceImpl.java
@@ -1,17 +1,17 @@
 package io.oduck.api.domain.voiceActor.service;
 
+import static io.oduck.api.domain.voiceActor.dto.VoiceActorReq.PostReq;
+
 import io.oduck.api.domain.voiceActor.dto.VoiceActorRes;
 import io.oduck.api.domain.voiceActor.entity.VoiceActor;
 import io.oduck.api.domain.voiceActor.repository.VoiceActorRepository;
+import io.oduck.api.global.exception.ConflictException;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static io.oduck.api.domain.voiceActor.dto.VoiceActorReq.PostReq;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +23,14 @@ public class VoiceActorServiceImpl implements VoiceActorService{
 
     @Override
     public void save(PostReq req) {
+        String name = req.getName();
+
+        boolean isExistsName = voiceActorRepository.existsByName(name);
+
+        if(isExistsName == true){
+            throw new ConflictException("Studio name");
+        }
+
         VoiceActor voiceActor = VoiceActor.builder()
                 .name(req.getName())
                 .build();

--- a/src/test/java/io/oduck/api/e2e/admin/AdminControllerTest.java
+++ b/src/test/java/io/oduck/api/e2e/admin/AdminControllerTest.java
@@ -461,7 +461,7 @@ public class AdminControllerTest {
         @Test
         @DisplayName("등록 성공 시 Http Status 204 반환")
         void postOriginalAuthor() throws Exception {
-            String name = "고토게 코요하루";
+            String name = "원작작가A";
             OriginalAuthorReq.PostReq postReq = new OriginalAuthorReq.PostReq(name);
             String content = gson.toJson(postReq);
 
@@ -484,6 +484,37 @@ public class AdminControllerTest {
                                             .description("원작 작가의 이름")
                             )
                     ));
+        }
+
+        @Test
+        @DisplayName("등록 실패 - 중복된 이름 : Http Status 409 반환")
+        void whenDuplicatedNameThenThrowException() throws Exception {
+            //given
+            String name = "고토게 코요하루";
+            OriginalAuthorReq.PostReq postReq = new OriginalAuthorReq.PostReq(name);
+            String content = gson.toJson(postReq);
+
+            //when
+            ResultActions actions = mockMvc.perform(
+                post(ADMIN_URL + "/original-authors")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .content(content)
+            );
+
+            //then
+            actions
+                .andExpect(status().isConflict())
+                .andDo(document("postOriginalAuthor/fail",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    requestFields(attributes(key("title").value("Fields for original author creation")),
+                        fieldWithPath("name")
+                            .type(JsonFieldType.STRING)
+                            .attributes(field("constraints", "공백을 허용하지 않습니다. 1~50자를 허용합니다."))
+                            .description("원작 작가의 이름")
+                    )
+                ));
         }
     }
 
@@ -536,13 +567,44 @@ public class AdminControllerTest {
                     .andDo(document("postVoiceActor/success",
                             preprocessRequest(prettyPrint()),
                             preprocessResponse(prettyPrint()),
-                            requestFields(attributes(key("title").value("Fields for original author creation")),
+                            requestFields(attributes(key("title").value("Fields for voice actor creation")),
                                     fieldWithPath("name")
                                             .type(JsonFieldType.STRING)
                                             .attributes(field("constraints", "공백을 허용하지 않습니다. 1~50자를 허용합니다."))
                                             .description("성우의 이름")
                             )
                     ));
+        }
+
+        @Test
+        @DisplayName("등록 실패 - 중복된 이름 : Http Status 409 반환")
+        void whenDuplicatedNameThenThrowException() throws Exception {
+            //given
+            String name = "하나에 나츠키";
+            VoiceActorReq.PostReq postReq = new VoiceActorReq.PostReq(name);
+            String content = gson.toJson(postReq);
+
+            //when
+            ResultActions actions = mockMvc.perform(
+                post(ADMIN_URL + "/voice-actors")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .content(content)
+            );
+
+            //then
+            actions
+                .andExpect(status().isConflict())
+                .andDo(document("postVoiceActor/fail",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    requestFields(attributes(key("title").value("Fields for original author creation")),
+                        fieldWithPath("name")
+                            .type(JsonFieldType.STRING)
+                            .attributes(field("constraints", "공백을 허용하지 않습니다. 1~50자를 허용합니다."))
+                            .description("성우의 이름")
+                    )
+                ));
         }
     }
 
@@ -578,8 +640,8 @@ public class AdminControllerTest {
 
         @Test
         @DisplayName("등록 성공 시 Http Status 204 반환")
-        void postVoiceActor() throws Exception {
-            String name = "ufortable";
+        void postStudio() throws Exception {
+            String name = "스튜디오A";
             StudioReq.PostReq postReq = new StudioReq.PostReq(name);
             String content = gson.toJson(postReq);
 
@@ -602,6 +664,37 @@ public class AdminControllerTest {
                                             .description("스튜디오의 이름")
                             )
                     ));
+        }
+
+        @Test
+        @DisplayName("등록 실패 - 중복된 이름 : Http Status 409 반환")
+        void whenDuplicatedNameThenThrowException() throws Exception {
+            //given
+            String name = "ufortable";
+            StudioReq.PostReq postReq = new StudioReq.PostReq(name);
+            String content = gson.toJson(postReq);
+
+            //when
+            ResultActions actions = mockMvc.perform(
+                post(ADMIN_URL + "/studios")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .content(content)
+            );
+
+            //then
+            actions
+                .andExpect(status().isConflict())
+                .andDo(document("postStudio/fail",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    requestFields(attributes(key("title").value("Fields for studio creation")),
+                        fieldWithPath("name")
+                            .type(JsonFieldType.STRING)
+                            .attributes(field("constraints", "공백을 허용하지 않습니다. 1~50자를 허용합니다."))
+                            .description("스튜디오의 이름")
+                    )
+                ));
         }
     }
 
@@ -639,7 +732,7 @@ public class AdminControllerTest {
         @Test
         @DisplayName("등록 성공 시 Http Status 204 반환")
         void postVoiceActor() throws Exception {
-            String name = "판타지";
+            String name = "이세계";
             GenreReq.PostReq postReq = new GenreReq.PostReq(name);
             String content = gson.toJson(postReq);
 
@@ -662,6 +755,37 @@ public class AdminControllerTest {
                                             .description("장르의 이름")
                             )
                     ));
+        }
+
+        @Test
+        @DisplayName("등록 실패 - 중복된 이름 : Http Status 409 반환")
+        void whenDuplicatedNameThenThrowException() throws Exception {
+            //given
+            String name = "판타지";
+            GenreReq.PostReq postReq = new GenreReq.PostReq(name);
+            String content = gson.toJson(postReq);
+
+            //when
+            ResultActions actions = mockMvc.perform(
+                post(ADMIN_URL + "/genres")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .content(content)
+            );
+
+            //then
+            actions
+                .andExpect(status().isConflict())
+                .andDo(document("postGenre/fail",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    requestFields(attributes(key("title").value("Fields for genre creation")),
+                        fieldWithPath("name")
+                            .type(JsonFieldType.STRING)
+                            .attributes(field("constraints", "공백을 허용하지 않습니다. 1~15자를 허용합니다."))
+                            .description("장르의 이름")
+                    )
+                ));
         }
     }
 
@@ -699,7 +823,7 @@ public class AdminControllerTest {
         @Test
         @DisplayName("등록 성공 시 Http Status 204 반환")
         void postSeries() throws Exception {
-            String title = "귀멸의 칼날";
+            String title = "스파이 패밀리";
             SeriesReq.PostReq postReq = new SeriesReq.PostReq(title);
             String content = gson.toJson(postReq);
 
@@ -722,6 +846,37 @@ public class AdminControllerTest {
                                             .description("시리즈의 제목")
                             )
                     ));
+        }
+
+        @Test
+        @DisplayName("등록 실패 - 중복된 이름 : Http Status 409 반환")
+        void whenDuplicatedNameThenThrowException() throws Exception {
+            //given
+            String name = "원피스";
+            SeriesReq.PostReq postReq = new SeriesReq.PostReq(name);
+            String content = gson.toJson(postReq);
+
+            //when
+            ResultActions actions = mockMvc.perform(
+                post(ADMIN_URL + "/series")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .content(content)
+            );
+
+            //then
+            actions
+                .andExpect(status().isConflict())
+                .andDo(document("postSeries/fail",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    requestFields(attributes(key("title").value("Fields for series creation")),
+                        fieldWithPath("title")
+                            .type(JsonFieldType.STRING)
+                            .attributes(field("constraints", "공백을 허용하지 않습니다. 1~50자를 허용합니다."))
+                            .description("시리즈의 제목")
+                    )
+                ));
         }
     }
 

--- a/src/test/java/io/oduck/api/unit/anime/repository/AnimeRepositoryTest.java
+++ b/src/test/java/io/oduck/api/unit/anime/repository/AnimeRepositoryTest.java
@@ -178,7 +178,7 @@ public class AnimeRepositoryTest {
              * 시리즈 생성
              */
             // 1. Series
-            String seriesTitle = "귀멸의 칼날";
+            String seriesTitle = "시리즈A";
             Series series = Series.builder()
                 .title(seriesTitle)
                 .build();

--- a/src/test/java/io/oduck/api/unit/anime/repository/AnimeRepositoryTest.java
+++ b/src/test/java/io/oduck/api/unit/anime/repository/AnimeRepositoryTest.java
@@ -1,9 +1,31 @@
 package io.oduck.api.unit.anime.repository;
 
+import static io.oduck.api.domain.anime.dto.AnimeRes.SearchResult;
+import static io.oduck.api.global.utils.AnimeTestUtils.getBroadcastType;
+import static io.oduck.api.global.utils.AnimeTestUtils.getEpisodeCount;
+import static io.oduck.api.global.utils.AnimeTestUtils.getQuarter;
+import static io.oduck.api.global.utils.AnimeTestUtils.getRating;
+import static io.oduck.api.global.utils.AnimeTestUtils.getStatus;
+import static io.oduck.api.global.utils.AnimeTestUtils.getSummary;
+import static io.oduck.api.global.utils.AnimeTestUtils.getThumbnail;
+import static io.oduck.api.global.utils.AnimeTestUtils.getTitle;
+import static io.oduck.api.global.utils.AnimeTestUtils.getYear;
+import static io.oduck.api.global.utils.AnimeTestUtils.isReleased;
+import static io.oduck.api.global.utils.PagingUtils.applyPageableForNonOffset;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.oduck.api.domain.anime.dto.AnimeReq;
 import io.oduck.api.domain.anime.dto.SearchFilterDsl;
-import io.oduck.api.domain.anime.entity.*;
-import io.oduck.api.domain.anime.repository.*;
+import io.oduck.api.domain.anime.entity.Anime;
+import io.oduck.api.domain.anime.entity.AnimeGenre;
+import io.oduck.api.domain.anime.entity.AnimeOriginalAuthor;
+import io.oduck.api.domain.anime.entity.AnimeStudio;
+import io.oduck.api.domain.anime.entity.AnimeVoiceActor;
+import io.oduck.api.domain.anime.repository.AnimeGenreRepository;
+import io.oduck.api.domain.anime.repository.AnimeOriginalAuthorRepository;
+import io.oduck.api.domain.anime.repository.AnimeRepository;
+import io.oduck.api.domain.anime.repository.AnimeStudioRepository;
+import io.oduck.api.domain.anime.repository.AnimeVoiceActorRepository;
 import io.oduck.api.domain.genre.entity.Genre;
 import io.oduck.api.domain.genre.repository.GenreRepository;
 import io.oduck.api.domain.originalAuthor.entity.OriginalAuthor;
@@ -15,6 +37,9 @@ import io.oduck.api.domain.studio.repository.StudioRepository;
 import io.oduck.api.domain.voiceActor.entity.VoiceActor;
 import io.oduck.api.domain.voiceActor.repository.VoiceActorRepository;
 import io.oduck.api.global.common.OrderDirection;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -24,15 +49,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-
-import static io.oduck.api.domain.anime.dto.AnimeRes.SearchResult;
-import static io.oduck.api.global.utils.AnimeTestUtils.*;
-import static io.oduck.api.global.utils.PagingUtils.applyPageableForNonOffset;
-import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Transactional
@@ -80,7 +96,7 @@ public class AnimeRepositoryTest {
              * 원작 작가 연관 관계 설정
              */
             // 1. OriginalAuthor 생성 size=1
-            String originalAuthorName = "엔도 타츠야";
+            String originalAuthorName = "원작작가";
             OriginalAuthor originalAuthor = OriginalAuthor.builder()
                 .name(originalAuthorName)
                 .build();
@@ -97,7 +113,7 @@ public class AnimeRepositoryTest {
              * 스튜디오 생성
              */
             // 1. Studio 생성 size=1
-            String studioName = "ufortable";
+            String studioName = "스튜디오A";
             Studio studio = Studio.builder()
                 .name(studioName)
                 .build();
@@ -239,7 +255,7 @@ public class AnimeRepositoryTest {
             List<OriginalAuthor> originalAuthors = new ArrayList<>();
             for (int i = 0; i < firstInsertSize; i++) {
                 OriginalAuthor originalAuthor = OriginalAuthor.builder()
-                    .name(originalAuthorName)
+                    .name(originalAuthorName+i)
                     .build();
                 originalAuthors.add(originalAuthor);
             }
@@ -308,7 +324,7 @@ public class AnimeRepositoryTest {
             List<Studio> studios = new ArrayList<>();
             for (int i = 0; i < firstInsertSize; i++) {
                 Studio studio = Studio.builder()
-                    .name(studioName)
+                    .name(studioName+i)
                     .build();
                 studios.add(studio);
             }
@@ -374,7 +390,7 @@ public class AnimeRepositoryTest {
             List<VoiceActor> voiceActors = new ArrayList<>();
             for (int i = 0; i < firstInsertSize; i++) {
                 VoiceActor voiceActor = VoiceActor.builder()
-                    .name(voiceActorName)
+                    .name(voiceActorName+i)
                     .build();
                 voiceActors.add(voiceActor);
             }
@@ -443,7 +459,7 @@ public class AnimeRepositoryTest {
             List<Genre> genres = new ArrayList<>();
             for (int i = 0; i < firstInsertSize; i++) {
                 Genre genre = Genre.builder()
-                    .name(genreName)
+                    .name(genreName+i)
                     .build();
                 genres.add(genre);
             }
@@ -472,7 +488,7 @@ public class AnimeRepositoryTest {
 
             //when
             //업데이트할 장르 생성
-            String updatingGenreName = "판타지";
+            String updatingGenreName = "이세계";
             Genre updatingGenre = Genre.builder()
                 .name(updatingGenreName)
                 .build();

--- a/src/test/java/io/oduck/api/unit/genre/repository/GenreRepositoryTest.java
+++ b/src/test/java/io/oduck/api/unit/genre/repository/GenreRepositoryTest.java
@@ -50,7 +50,7 @@ public class GenreRepositoryTest {
         void findGenre() {
             //given
             Genre genre = Genre.builder()
-                    .name("판타지")
+                    .name("이세계")
                     .build();
 
             Genre savedGenre = genreRepository.save(genre);

--- a/src/test/java/io/oduck/api/unit/originalAuthor/repository/OriginalAuthorRepositoryTest.java
+++ b/src/test/java/io/oduck/api/unit/originalAuthor/repository/OriginalAuthorRepositoryTest.java
@@ -30,7 +30,7 @@ public class OriginalAuthorRepositoryTest {
         void SaveOriginalAuthor() {
             //given
             OriginalAuthor originalAuthor = OriginalAuthor.builder()
-                    .name("엔도 타츠야")
+                    .name("원작작가A")
                     .build();
 
             //when

--- a/src/test/java/io/oduck/api/unit/studio/repository/StudioRepositoryTest.java
+++ b/src/test/java/io/oduck/api/unit/studio/repository/StudioRepositoryTest.java
@@ -30,7 +30,7 @@ public class StudioRepositoryTest {
         void saveStudio() {
             //given
             Studio studio = Studio.builder()
-                    .name("ufortable")
+                    .name("스튜디오A")
                     .build();
 
             Studio savedStudio = studioRepository.save(studio);


### PR DESCRIPTION
## 📝 개요
## 🚀 변경사항
- 애니 관련 5개 도메인(원작 작가, 스튜디오, 장르, 성우, 시리즈) 중복 처리 로직 추가 및 데이터베이스에서 유니크 설정하였습니다.

## 🔗 관련 이슈
#71 