### PR TITLE
짧은 리뷰 좋아요 생성, 삭제, 좋아요 유무 확인 #69

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -356,7 +356,55 @@ include::{snippets}/patchShortReviewReq/success/http-response.adoc[]
 
 ==== 실패시
 
-==== 실패시
+== shortReviewLike
+=== POST api/v1/likes
+.curl-request
+include::{snippets}/likes/shortReview/save/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/likes/shortReview/save/success/http-request.adoc[]
+
+.request-header
+include::{snippets}/likes/shortReview/save/success/request-headers.adoc[]
+
+.request-body
+include::{snippets}/likes/shortReview/save/success/request-body.adoc[]
+
+.request-fields
+include::{snippets}/likes/shortReview/save/success/request-fields.adoc[]
+
+==== 저장 성공시
+.http-response
+include::{snippets}/likes/shortReview/save/success/http-response.adoc[]
+
+==== 삭제 성공시
+.http-response
+include::{snippets}/likes/shortReview/delete/success/http-response.adoc[]
+
+== 짧은 리뷰 좋아요 존재 여부
+=== GET api/v1/likes/:shortReviewId
+.curl-request
+include::{snippets}/likes/shortReview/checkLike/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/likes/shortReview/checkLike/success/http-request.adoc[]
+
+.path-parameters
+include::{snippets}/likes/shortReview/checkLike/success/path-parameters.adoc[]
+
+.request-header
+include::{snippets}/likes/shortReview/checkLike/success/request-headers.adoc[]
+
+=== 짧은 리뷰 좋아요 존재 여부
+.http-response
+include::{snippets}/likes/shortReview/checkLike/success/http-response.adoc[]
+
+.response-body
+include::{snippets}/likes/shortReview/checkLike/success/response-body.adoc[]
+
+.response-fields
+include::{snippets}/likes/shortReview/checkLike/success/response-fields.adoc[]
+
 
 == admin
 
@@ -711,3 +759,5 @@ include::{snippets}/postSeries/success/request-fields.adoc[]
 include::{snippets}/postSeries/success/http-response.adoc[]
 
 ==== 실패 시
+
+====

--- a/src/main/java/io/oduck/api/domain/reviewLike/controller/ShortReviewLikeController.java
+++ b/src/main/java/io/oduck/api/domain/reviewLike/controller/ShortReviewLikeController.java
@@ -1,0 +1,49 @@
+
+package io.oduck.api.domain.reviewLike.controller;
+
+import io.oduck.api.domain.reviewLike.dto.ShortReviewLikeReqDto;
+import io.oduck.api.domain.reviewLike.dto.ShortReviewLikeResDto;
+import io.oduck.api.domain.reviewLike.dto.ShortReviewLikeReqDto.ShortReviewLikeReq;
+import io.oduck.api.domain.reviewLike.service.ShortReviewLikeService;
+import io.oduck.api.global.security.auth.dto.AuthUser;
+import io.oduck.api.global.security.auth.dto.LoginUser;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequestMapping("/likes")
+@RequiredArgsConstructor
+public class ShortReviewLikeController {
+
+    final private ShortReviewLikeService shortReviewLikeService;
+
+    @PostMapping
+    public ResponseEntity<?> postLike(
+        @LoginUser AuthUser user,
+        @RequestBody @Valid ShortReviewLikeReq likeRes
+    ){
+        //TODO: 리뷰 좋아요 생성, 존재하지 않다면 생성, 존재한다면 삭제
+        boolean postLike = shortReviewLikeService.postLike(user.getId(), likeRes);
+        return ResponseEntity.status(postLike ? HttpStatus.CREATED : HttpStatus.NO_CONTENT).build();
+    }
+
+    @GetMapping("/{shortReviewId}")
+    public ResponseEntity<?> getLike(
+        @PathVariable Long shortReviewId,
+        @LoginUser AuthUser user
+    ){
+        //TODO: 좋아요한 리뷰인지 확인
+        return ResponseEntity.ok(shortReviewLikeService.checkReviewLike(shortReviewId, user.getId()));
+    }
+
+}

--- a/src/main/java/io/oduck/api/domain/reviewLike/dto/ShortReviewLikeReqDto.java
+++ b/src/main/java/io/oduck/api/domain/reviewLike/dto/ShortReviewLikeReqDto.java
@@ -1,0 +1,17 @@
+package io.oduck.api.domain.reviewLike.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ShortReviewLikeReqDto {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ShortReviewLikeReq{
+        Long shortReviewId;
+    }
+
+}

--- a/src/main/java/io/oduck/api/domain/reviewLike/dto/ShortReviewLikeResDto.java
+++ b/src/main/java/io/oduck/api/domain/reviewLike/dto/ShortReviewLikeResDto.java
@@ -1,0 +1,17 @@
+package io.oduck.api.domain.reviewLike.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ShortReviewLikeResDto {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class HasLikeRes{
+        private boolean hasLike;
+    }
+}

--- a/src/main/java/io/oduck/api/domain/reviewLike/repository/ShortReviewLikeRepository.java
+++ b/src/main/java/io/oduck/api/domain/reviewLike/repository/ShortReviewLikeRepository.java
@@ -1,10 +1,13 @@
 package io.oduck.api.domain.reviewLike.repository;
 
 import io.oduck.api.domain.reviewLike.entity.ShortReviewLike;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ShortReviewLikeRepository extends JpaRepository<ShortReviewLike,Long> {
+
+    Optional<ShortReviewLike> findByMemberIdAndShortReviewId(Long memberId, Long shortReviewId);
 
 }

--- a/src/main/java/io/oduck/api/domain/reviewLike/service/ShortReviewLikeService.java
+++ b/src/main/java/io/oduck/api/domain/reviewLike/service/ShortReviewLikeService.java
@@ -1,0 +1,15 @@
+package io.oduck.api.domain.reviewLike.service;
+
+
+import io.oduck.api.domain.reviewLike.dto.ShortReviewLikeReqDto.ShortReviewLikeReq;
+import io.oduck.api.domain.reviewLike.dto.ShortReviewLikeResDto.HasLikeRes;
+
+public interface ShortReviewLikeService {
+
+    //리뷰 좋아요
+    Boolean postLike(Long memberId, ShortReviewLikeReq likeRes);
+
+    //리뷰 좋아요 유무
+    HasLikeRes checkReviewLike(Long likeId, Long memberId);
+
+}

--- a/src/main/java/io/oduck/api/domain/reviewLike/service/ShortReviewLikeServiceImpl.java
+++ b/src/main/java/io/oduck/api/domain/reviewLike/service/ShortReviewLikeServiceImpl.java
@@ -1,0 +1,62 @@
+package io.oduck.api.domain.reviewLike.service;
+
+import io.oduck.api.domain.member.entity.Member;
+import io.oduck.api.domain.member.repository.MemberRepository;
+import io.oduck.api.domain.review.entity.ShortReview;
+import io.oduck.api.domain.review.repository.ShortReviewRepository;
+import io.oduck.api.domain.reviewLike.dto.ShortReviewLikeReqDto.ShortReviewLikeReq;
+import io.oduck.api.domain.reviewLike.dto.ShortReviewLikeResDto.HasLikeRes;
+import io.oduck.api.domain.reviewLike.entity.ShortReviewLike;
+import io.oduck.api.domain.reviewLike.repository.ShortReviewLikeRepository;
+import io.oduck.api.global.exception.NotFoundException;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ShortReviewLikeServiceImpl implements ShortReviewLikeService{
+
+    final private ShortReviewLikeRepository shortReviewLikeRepository;
+    final private ShortReviewRepository shortReviewRepository;
+    final private MemberRepository memberRepository;
+
+    @Override
+    public Boolean postLike(Long memberId, ShortReviewLikeReq likeRes) {
+        //리뷰 좋아요 작성 여부 확인 후 없으면 생성 있으면 삭제 리뷰 찾기 회원 찾기
+        Optional<ShortReviewLike> optionalLike = getShortReviewLike(memberId, likeRes.getShortReviewId());
+        if(optionalLike.isPresent()){
+            shortReviewLikeRepository.delete(optionalLike.get());
+            return false;
+        }
+        ShortReview shortReview = shortReviewRepository.findById(likeRes.getShortReviewId())
+                                      .orElseThrow(() -> new NotFoundException("ShortReview"));
+
+        Member member = memberRepository.findById(memberId)
+                            .orElseThrow(() -> new NotFoundException("Member"));
+
+        ShortReviewLike like = ShortReviewLike
+                                   .builder()
+                                   .shortReview(shortReview)
+                                   .member(member)
+                                   .build();
+
+        shortReviewLikeRepository.save(like);
+        return true;
+    }
+
+    @Override
+    public HasLikeRes checkReviewLike(Long shortReviewId, Long memberId) {
+        Optional<ShortReviewLike> optionalLike = getShortReviewLike(memberId, shortReviewId);
+        return HasLikeRes
+                   .builder()
+                   .hasLike(optionalLike.isPresent())
+                   .build();
+    }
+
+    private Optional<ShortReviewLike> getShortReviewLike(Long memberId, Long shortReviewId){
+        return shortReviewLikeRepository.findByMemberIdAndShortReviewId(memberId,shortReviewId);
+    }
+}

--- a/src/test/java/io/oduck/api/e2e/shortReviewLike/ShortReviewLikeControllerTest.java
+++ b/src/test/java/io/oduck/api/e2e/shortReviewLike/ShortReviewLikeControllerTest.java
@@ -1,0 +1,192 @@
+package io.oduck.api.e2e.shortReviewLike;
+
+import static io.oduck.api.global.config.RestDocsConfig.field;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.snippet.Attributes.attributes;
+import static org.springframework.restdocs.snippet.Attributes.key;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.google.gson.Gson;
+import io.oduck.api.domain.member.entity.Role;
+import io.oduck.api.domain.reviewLike.dto.ShortReviewLikeReqDto.ShortReviewLikeReq;
+import io.oduck.api.global.mockMember.WithCustomMockMember;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc
+@ExtendWith({ RestDocumentationExtension.class, SpringExtension.class })
+@SpringBootTest
+@ActiveProfiles("test")
+public class ShortReviewLikeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private Gson gson;
+
+    private final String BASE_URL = "/likes";
+
+    @Nested
+    @DisplayName("리뷰 좋아요")
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    class PostLike{
+
+        @Test
+        @DisplayName("짧은 리뷰 좋아요 성공")
+        @Order(1)
+        @WithCustomMockMember(id = 2L, email = "john", password = "Qwer!234", role = Role.MEMBER)
+        void shortReviewLikeSaveSuccess() throws Exception{
+            //given
+            ShortReviewLikeReq likeRes = ShortReviewLikeReq
+                                             .builder()
+                                             .shortReviewId(1L)
+                                             .build();
+            String content = gson.toJson(likeRes);
+
+            //when
+            ResultActions actions = mockMvc.perform(
+                post(BASE_URL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.COOKIE, "oDuckio.sid={SESSION_VALUE}")
+                    .content(content)
+            );
+
+            //then
+            actions
+                .andExpect(status().isCreated())
+                .andDo(document("likes/shortReview/save/success",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                            headerWithName(HttpHeaders.COOKIE)
+                                .attributes(field("constraints", "oDuckio.sid={SESSION_VALUE}"))
+                                .description("Header Cookie, 세션 쿠키")
+                        ),
+                        requestFields(attributes(key("title").value("Fields for shortReviewLike creation")),
+                            fieldWithPath("shortReviewId")
+                                .type(JsonFieldType.NUMBER)
+                                .attributes(field("constraints", "짧은 리뷰 아이디, NotNull, Min(1)"))
+                                .description("짧은 리뷰 좋아요를 등록할 리뷰 고유 식별 번호"))
+                    )
+                );
+        }
+
+        @Test
+        @DisplayName("짧은 리뷰 좋아요 삭제 성공")
+        @Order(2)
+        @WithCustomMockMember(id = 2L, email = "john", password = "Qwer!234", role = Role.MEMBER)
+        void shorReviewLikeDeleteSuccess() throws Exception{
+            //given
+            ShortReviewLikeReq likeRes = ShortReviewLikeReq
+                                             .builder()
+                                             .shortReviewId(1L)
+                                             .build();
+            String content = gson.toJson(likeRes);
+
+            //when
+            ResultActions actions = mockMvc.perform(
+                post(BASE_URL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.COOKIE, "oDuckio.sid={SESSION_VALUE}")
+                    .content(content)
+            );
+
+            //then
+            actions
+                .andExpect(status().isNoContent())
+                .andDo(document("likes/shortReview/delete/success",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                            headerWithName(HttpHeaders.COOKIE)
+                                .attributes(field("constraints", "oDuckio.sid={SESSION_VALUE}"))
+                                .description("Header Cookie, 세션 쿠키")
+                        ),
+                        requestFields(attributes(key("title").value("Fields for shortReviewLike creation")),
+                            fieldWithPath("shortReviewId")
+                                .type(JsonFieldType.NUMBER)
+                                .attributes(field("constraints", "짧은 리뷰 아이디, NotNull, Min(1)"))
+                                .description("짧은 리뷰 좋아요를 등록할 리뷰 고유 식별 번호"))
+                    )
+                );
+        }
+    }
+
+    @Nested
+    @DisplayName("리뷰 좋아요 여부")
+    class CheckLike{
+
+        @Test
+        @DisplayName("짧은 리뷰 좋아요 존재 여부")
+        @WithCustomMockMember(id = 1L, email = "john", password = "Qwer!234", role = Role.MEMBER)
+        void checkShortReviewLike() throws Exception{
+            //given
+            Long shortReviewId = 1L;
+
+            //when
+            ResultActions actions = mockMvc.perform(
+                get(BASE_URL + "/{shortReviewId}", shortReviewId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.COOKIE, "oDuckio.sid={SESSION_VALUE}"));
+
+            //then
+            actions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.hasLike").exists())
+                .andDo(document("likes/shortReview/checkLike/success",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                            headerWithName(HttpHeaders.COOKIE)
+                                .attributes(field("constraints", "oDuckio.sid={SESSION_VALUE}"))
+                                .description("Header Cookie, 세션 쿠키")
+                        ),
+                        pathParameters(
+                            parameterWithName("shortReviewId")
+                                .description("짧은 리뷰 고유 식별자")
+                        ),
+                        responseFields(
+                            fieldWithPath("hasLike")
+                                .type(JsonFieldType.BOOLEAN)
+                                .description("짧은 리뷰 좋아요 존재 시 true, 부재 시 false"))
+                    )
+                );
+        }
+    }
+
+}

--- a/src/test/java/io/oduck/api/unit/shortReviewLike/repository/ShortReviewLikeRepositoryTest.java
+++ b/src/test/java/io/oduck/api/unit/shortReviewLike/repository/ShortReviewLikeRepositoryTest.java
@@ -1,0 +1,132 @@
+package io.oduck.api.unit.shortReviewLike.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.oduck.api.domain.member.entity.Member;
+import io.oduck.api.domain.member.repository.MemberRepository;
+import io.oduck.api.domain.review.entity.ShortReview;
+import io.oduck.api.domain.review.repository.ShortReviewRepository;
+import io.oduck.api.domain.reviewLike.entity.ShortReviewLike;
+import io.oduck.api.domain.reviewLike.repository.ShortReviewLikeRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+public class ShortReviewLikeRepositoryTest {
+
+    @Autowired
+    private ShortReviewLikeRepository shortReviewLikeRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ShortReviewRepository shortReviewRepository;
+
+    Member member = Member
+                        .builder()
+                        .id(2L)
+                        .build();
+    ShortReview shortReview = ShortReview
+                                  .builder()
+                                  .id(1L)
+                                  .build();
+
+    @Nested
+    @DisplayName("짧은 리뷰 좋아요 저장, 삭제")
+    class PostLike{
+
+        @Test
+        @DisplayName("짧은 리뷰 좋아요 저장 성공")
+        void shortReviewLikeSaveSuccess() {
+            //given
+            ShortReviewLike shortReviewLike = ShortReviewLike
+                                                  .builder()
+                                                  .member(member)
+                                                  .shortReview(shortReview)
+                                                  .build();
+
+            ShortReviewLike findLike = shortReviewLikeRepository.findByMemberIdAndShortReviewId(member.getId(), shortReview.getId()).orElse(null);
+            ShortReviewLike saveLike = shortReviewLikeRepository.save(shortReviewLike);
+
+            assertNull(findLike);
+            assertEquals(member.getId(), saveLike.getMember().getId());
+            assertEquals(shortReview.getId(), saveLike.getShortReview().getId());
+        }
+
+        @Test
+        @DisplayName("짧은 리뷰 좋아요 삭제 성공")
+        void shortReviewLikeDeleteSuccess(){
+            //given
+            ShortReviewLike shortReviewLike = ShortReviewLike
+                                                  .builder()
+                                                  .member(member)
+                                                  .shortReview(shortReview)
+                                                  .build();
+
+            ShortReviewLike saveLike = shortReviewLikeRepository.save(shortReviewLike);
+
+            //when
+            ShortReviewLike findLike = shortReviewLikeRepository.findByMemberIdAndShortReviewId(member.getId(), shortReview.getId()).orElse(shortReviewLike);
+            shortReviewLikeRepository.delete(findLike);
+
+            //then
+            ShortReviewLike deleteLike = shortReviewLikeRepository.findByMemberIdAndShortReviewId(member.getId(), shortReview.getId()).orElse(null);
+            assertNotNull(findLike);
+            assertThat(deleteLike).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("짧은 리뷰 존재 유무")
+    class CheckLike{
+
+        @Test
+        @DisplayName("짧은 리뷰 좋아요 존재 시 true")
+        void checkShortReviewLikeTrue(){
+            //given
+            ShortReviewLike shortReviewLike = ShortReviewLike
+                                                  .builder()
+                                                  .member(member)
+                                                  .shortReview(shortReview)
+                                                  .build();
+
+            ShortReviewLike saveLike = shortReviewLikeRepository.save(shortReviewLike);
+
+            //when
+            boolean findLike = shortReviewLikeRepository.findByMemberIdAndShortReviewId(member.getId(), shortReview.getId()).isPresent();
+
+            //then
+            assertTrue(findLike);
+        }
+
+        @Test
+        @DisplayName("짧은 리뷰 좋아요 없을 시 false")
+        void checkShortReviewLikeFalse(){
+            //given
+            ShortReviewLike shortReviewLike = ShortReviewLike
+                                                  .builder()
+                                                  .member(member)
+                                                  .shortReview(shortReview)
+                                                  .build();
+
+            //when
+            boolean findLike = shortReviewLikeRepository.findByMemberIdAndShortReviewId(member.getId(), shortReview.getId()).isPresent();
+
+            //then
+            assertFalse(findLike);
+        }
+    }
+}

--- a/src/test/java/io/oduck/api/unit/shortReviewLike/service/ShortReviewLikeServiceTest.java
+++ b/src/test/java/io/oduck/api/unit/shortReviewLike/service/ShortReviewLikeServiceTest.java
@@ -1,0 +1,123 @@
+package io.oduck.api.unit.shortReviewLike.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import io.oduck.api.domain.member.entity.Member;
+import io.oduck.api.domain.member.repository.MemberRepository;
+import io.oduck.api.domain.review.entity.ShortReview;
+import io.oduck.api.domain.review.repository.ShortReviewRepository;
+import io.oduck.api.domain.reviewLike.dto.ShortReviewLikeReqDto.ShortReviewLikeReq;
+import io.oduck.api.domain.reviewLike.dto.ShortReviewLikeResDto.HasLikeRes;
+import io.oduck.api.domain.reviewLike.entity.ShortReviewLike;
+import io.oduck.api.domain.reviewLike.repository.ShortReviewLikeRepository;
+import io.oduck.api.domain.reviewLike.service.ShortReviewLikeServiceImpl;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ShortReviewLikeServiceTest {
+    @InjectMocks
+    private ShortReviewLikeServiceImpl shortReviewLikeService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private ShortReviewRepository shortReviewRepository;
+
+    @Mock
+    private ShortReviewLikeRepository shortReviewLikeRepository;
+
+        Member member = Member
+                            .builder()
+                            .id(1L)
+                            .build();
+
+        ShortReview shortReview = ShortReview
+                                      .builder()
+                                      .id(1L)
+                                      .build();
+
+       ShortReviewLike shortReviewLike = ShortReviewLike
+                                             .builder()
+                                             .member(member)
+                                             .shortReview(shortReview)
+                                             .build();
+
+       ShortReviewLikeReq req = ShortReviewLikeReq
+                                    .builder()
+                                    .shortReviewId(1L)
+                                    .build();
+
+    @Nested
+    @DisplayName("짧은 리뷰 좋아요")
+    class PostLike{
+
+        @Test
+        @DisplayName("짧은 리뷰 좋아요 생성 성공")
+        void shortReviewLikeSaveSuccess() {
+            //given
+            given(shortReviewLikeRepository.findByMemberIdAndShortReviewId(anyLong(),anyLong()))
+                .willReturn(Optional.empty());
+            given(memberRepository.findById(anyLong())).willReturn(Optional.of(member));
+            given(shortReviewRepository.findById(anyLong())).willReturn(Optional.of(shortReview));
+
+            boolean result = shortReviewLikeService.postLike(member.getId(), req);
+
+            assertDoesNotThrow(() -> shortReviewLikeService.postLike(member.getId(), req));
+            assertTrue(result);
+        }
+
+        @Test
+        @DisplayName("짧은 리뷰 좋아요 삭제 성공")
+        void shortReviewLikeDeleteSuccess(){
+            //given(shortReviewLikeRepository.save(shortReviewLike));
+            given(shortReviewLikeRepository.findByMemberIdAndShortReviewId(anyLong(), anyLong()))
+                .willReturn(Optional.of(shortReviewLike));
+
+            shortReviewLikeRepository.delete(shortReviewLike);
+            boolean result = shortReviewLikeService.postLike(member.getId(), req);
+
+            assertDoesNotThrow(() -> shortReviewLikeService.postLike(member.getId(), req));
+            assertFalse(result);
+        }
+    }
+
+    @Nested
+    @DisplayName("짧은 리뷰 존재 유무")
+    class CheckLike{
+
+        @Test
+        @DisplayName("짧은 리뷰 좋아요 존재 시 true")
+        void checkShortReviewLikeTrue(){
+            given(shortReviewLikeRepository.findByMemberIdAndShortReviewId(member.getId(), shortReview.getId())).willReturn(Optional.of(shortReviewLike));
+
+            HasLikeRes hasLikeRes = shortReviewLikeService.checkReviewLike(shortReview.getId(), member.getId());
+
+            assertNotNull(hasLikeRes);
+            assertTrue(hasLikeRes.isHasLike());
+        }
+
+        @Test
+        @DisplayName("짧은 리뷰 좋아요 없을 시 false")
+        void checkShortReviewLikeFalse(){
+            given(shortReviewLikeRepository.findByMemberIdAndShortReviewId(member.getId(), shortReview.getId())).willReturn(Optional.empty());
+
+            HasLikeRes hasLikeRes = shortReviewLikeService.checkReviewLike(shortReview.getId(), member.getId());
+
+            assertNotNull(hasLikeRes);
+            assertFalse(hasLikeRes.isHasLike());
+        }
+    }
+}

--- a/src/test/resources/db/data.sql
+++ b/src/test/resources/db/data.sql
@@ -73,4 +73,4 @@ INSERT INTO short_review(has_spoiler, anime_id, created_at, member_id, updated_a
 INSERT INTO short_review(has_spoiler, anime_id, created_at, member_id, updated_at, content) VALUES(0, 2, '2023-10-11 21:05:31.859', 1, '2023-10-11 21:05:31.859', '힐링');
 
 INSERT INTO short_review_like(created_at, member_id, short_review_id, updated_at) VALUES('2023-10-10 21:05:31.859', 1, 1, '2023-10-10 21:05:31.859');
-INSERT INTO short_review_like(created_at, member_id, short_review_id, updated_at) VALUES('2023-10-11 21:05:31.859', 1, 1, '2023-10-11 21:05:31.859');
+INSERT INTO short_review_like(created_at, member_id, short_review_id, updated_at) VALUES('2023-10-11 21:05:31.859', 1, 2, '2023-10-11 21:05:31.859');


### PR DESCRIPTION
## 📝 개요
짧은 리뷰 좋아요 생성, 삭제, 좋아요 유무 확인 구현

## 🚀 변경사항

짧은 리뷰 좋아요 컨트롤러, 리포지토리, 서비스 구현
짧은 리뷰 좋아요 테스트 추가
짧은 리뷰 좋아요 api문서 추가

## 🔗 관련 이슈

#69

## ➕ 기타
![image](https://github.com/oduck-team/oduck-server/assets/119990091/e135d424-924a-4db9-af3c-48bad914004c)
![image](https://github.com/oduck-team/oduck-server/assets/119990091/5e0de671-c4e2-4a62-ad62-49ef52f7eacf)

동일한 insert문으로 short_review_id를 2로 수정했습니다.

