### PR TITLE
애니 관련 도메인 수정, 삭제 구현 #63

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -688,6 +688,43 @@ include::{snippets}/postOriginalAuthor/success/http-response.adoc[]
 .http-response
 include::{snippets}/postOriginalAuthor/fail/http-response.adoc[]
 
+=== PATCH api/v1/oduckdmin/original-authors/:id
+.curl-request
+include::{snippets}/patchOriginalAuthor/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/patchOriginalAuthor/success/http-request.adoc[]
+
+.request-param
+include::{snippets}/patchOriginalAuthor/success/path-parameters.adoc[]
+
+.request-fields
+include::{snippets}/patchOriginalAuthor/success/request-fields.adoc[]
+
+==== 성공시
+
+.http-response
+include::{snippets}/patchOriginalAuthor/success/http-response.adoc[]
+
+==== 실패시
+
+=== DELETE api/v1/oduckdmin/original-authors/:id
+.curl-request
+include::{snippets}/deleteOriginalAuthor/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/deleteOriginalAuthor/success/http-request.adoc[]
+
+.request-param
+include::{snippets}/deleteOriginalAuthor/success/path-parameters.adoc[]
+
+==== 성공시
+
+.http-response
+include::{snippets}/deleteOriginalAuthor/success/http-response.adoc[]
+
+==== 실패시
+
 === GET api/v1/oduckdmin/voice-actors
 
 .curl-request
@@ -728,6 +765,43 @@ include::{snippets}/postVoiceActor/success/http-response.adoc[]
 ==== 실패 시(이름 중복)
 .http-response
 include::{snippets}/postVoiceActor/fail/http-response.adoc[]
+
+=== PATCH api/v1/oduckdmin/voice-actors/:id
+.curl-request
+include::{snippets}/patchVoiceActor/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/patchVoiceActor/success/http-request.adoc[]
+
+.request-param
+include::{snippets}/patchVoiceActor/success/path-parameters.adoc[]
+
+.request-fields
+include::{snippets}/patchVoiceActor/success/request-fields.adoc[]
+
+==== 성공시
+
+.http-response
+include::{snippets}/patchVoiceActor/success/http-response.adoc[]
+
+==== 실패시
+
+=== DELETE api/v1/oduckdmin/voice-actors/:id
+.curl-request
+include::{snippets}/deleteVoiceActor/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/deleteVoiceActor/success/http-request.adoc[]
+
+.request-param
+include::{snippets}/deleteVoiceActor/success/path-parameters.adoc[]
+
+==== 성공시
+
+.http-response
+include::{snippets}/deleteVoiceActor/success/http-response.adoc[]
+
+==== 실패시
 
 === GET api/v1/oduckdmin/studios
 
@@ -770,6 +844,43 @@ include::{snippets}/postStudio/success/http-response.adoc[]
 .http-response
 include::{snippets}/postStudio/fail/http-response.adoc[]
 
+=== PATCH api/v1/oduckdmin/studios/:id
+.curl-request
+include::{snippets}/patchStudio/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/patchStudio/success/http-request.adoc[]
+
+.request-param
+include::{snippets}/patchStudio/success/path-parameters.adoc[]
+
+.request-fields
+include::{snippets}/patchStudio/success/request-fields.adoc[]
+
+==== 성공시
+
+.http-response
+include::{snippets}/patchStudio/success/http-response.adoc[]
+
+==== 실패시
+
+=== DELETE api/v1/oduckdmin/studios/:id
+.curl-request
+include::{snippets}/deleteStudio/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/deleteStudio/success/http-request.adoc[]
+
+.request-param
+include::{snippets}/deleteStudio/success/path-parameters.adoc[]
+
+==== 성공시
+
+.http-response
+include::{snippets}/deleteStudio/success/http-response.adoc[]
+
+==== 실패시
+
 === GET api/v1/oduckdmin/genres
 
 .curl-request
@@ -810,6 +921,43 @@ include::{snippets}/postGenre/success/http-response.adoc[]
 ==== 실패 시 (이름 중복)
 .http-response
 include::{snippets}/postGenre/fail/http-response.adoc[]
+
+=== PATCH api/v1/oduckdmin/genres/:id
+.curl-request
+include::{snippets}/patchGenre/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/patchGenre/success/http-request.adoc[]
+
+.request-param
+include::{snippets}/patchGenre/success/path-parameters.adoc[]
+
+.request-fields
+include::{snippets}/patchGenre/success/request-fields.adoc[]
+
+==== 성공시
+
+.http-response
+include::{snippets}/patchGenre/success/http-response.adoc[]
+
+==== 실패시
+
+=== DELETE api/v1/oduckdmin/genres/:id
+.curl-request
+include::{snippets}/deleteGenre/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/deleteGenre/success/http-request.adoc[]
+
+.request-param
+include::{snippets}/deleteGenre/success/path-parameters.adoc[]
+
+==== 성공시
+
+.http-response
+include::{snippets}/deleteGenre/success/http-response.adoc[]
+
+==== 실패시
 
 === GET api/v1/oduckdmin/series
 
@@ -852,6 +1000,43 @@ include::{snippets}/postSeries/success/http-response.adoc[]
 .http-response
 include::{snippets}/postSeries/fail/http-response.adoc[]
 ==== 실패 시
+
+=== PATCH api/v1/oduckdmin/series/:id
+.curl-request
+include::{snippets}/patchSeries/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/patchSeries/success/http-request.adoc[]
+
+.request-param
+include::{snippets}/patchSeries/success/path-parameters.adoc[]
+
+.request-fields
+include::{snippets}/patchSeries/success/request-fields.adoc[]
+
+==== 성공시
+
+.http-response
+include::{snippets}/patchSeries/success/http-response.adoc[]
+
+==== 실패시
+
+=== DELETE api/v1/oduckdmin/series/:id
+.curl-request
+include::{snippets}/deleteSeries/success/curl-request.adoc[]
+
+.http-request
+include::{snippets}/deleteSeries/success/http-request.adoc[]
+
+.request-param
+include::{snippets}/deleteSeries/success/path-parameters.adoc[]
+
+==== 성공시
+
+.http-response
+include::{snippets}/deleteSeries/success/http-response.adoc[]
+
+==== 실패시
 
 == starRating
 === POST api/v1/ratings

--- a/src/main/java/io/oduck/api/domain/admin/controller/AdminController.java
+++ b/src/main/java/io/oduck/api/domain/admin/controller/AdminController.java
@@ -152,6 +152,28 @@ public class AdminController {
         return ResponseEntity.ok(originalAuthors);
     }
 
+    // 원작 작가 수정
+    @PatchMapping("/original-authors/{originalAuthorId}")
+    public ResponseEntity<Object> patchOriginalAuthor(
+        @PathVariable Long originalAuthorId, @RequestBody @Valid OriginalAuthorReq.PatchReq req
+    ){
+
+        originalAuthorService.update(originalAuthorId, req.getName());
+
+        return ResponseEntity.noContent().build();
+    }
+
+    // 원작 작가 삭제
+    @DeleteMapping("/original-authors/{originalAuthorId}")
+    public ResponseEntity<Object> deleteOriginalAuthor(
+        @PathVariable Long originalAuthorId
+    ){
+
+        originalAuthorService.delete(originalAuthorId);
+
+        return ResponseEntity.noContent().build();
+    }
+
     // 성우 추가
     @PostMapping("/voice-actors")
     public ResponseEntity<Object> postVoiceActor(@RequestBody @Valid VoiceActorReq.PostReq req) {
@@ -168,6 +190,28 @@ public class AdminController {
         List<VoiceActorRes> voiceActors = voiceActorService.getVoiceActors();
 
         return ResponseEntity.ok(voiceActors);
+    }
+
+    // 성우 수정
+    @PatchMapping("/voice-actors/{voiceActorId}")
+    public ResponseEntity<Object> patchVoiceActor(
+        @PathVariable Long voiceActorId, @RequestBody @Valid VoiceActorReq.PatchReq req
+    ){
+
+        voiceActorService.update(voiceActorId, req.getName());
+
+        return ResponseEntity.noContent().build();
+    }
+
+    // 성우 삭제
+    @DeleteMapping("/voice-actors/{voiceActorId}")
+    public ResponseEntity<Object> deleteVoiceActor(
+        @PathVariable Long voiceActorId
+    ){
+
+        voiceActorService.delete(voiceActorId);
+
+        return ResponseEntity.noContent().build();
     }
 
     // 스튜디오 추가
@@ -188,6 +232,28 @@ public class AdminController {
         return ResponseEntity.ok(studios);
     }
 
+    // 스튜디오 수정
+    @PatchMapping("/studios/{studioId}")
+    public ResponseEntity<Object> patchStudio(
+        @PathVariable Long studioId, @RequestBody @Valid StudioReq.PatchReq req
+    ){
+
+        studioService.update(studioId, req.getName());
+
+        return ResponseEntity.noContent().build();
+    }
+
+    // 스튜디오 삭제
+    @DeleteMapping("/studios/{studioId}")
+    public ResponseEntity<Object> deleteStudio(
+        @PathVariable Long studioId
+    ){
+
+        studioService.delete(studioId);
+
+        return ResponseEntity.noContent().build();
+    }
+
     // 장르 추가
     @PostMapping("/genres")
     public ResponseEntity<Object> postGenre(@RequestBody @Valid GenreReq.PostReq req) {
@@ -206,6 +272,28 @@ public class AdminController {
         return ResponseEntity.ok(genres);
     }
 
+    // 장르 수정
+    @PatchMapping("/genres/{genreId}")
+    public ResponseEntity<Object> patchGenre(
+        @PathVariable Long genreId, @RequestBody @Valid GenreReq.PatchReq req
+    ){
+
+        genreService.update(genreId, req.getName());
+
+        return ResponseEntity.noContent().build();
+    }
+
+    // 장르 삭제
+    @DeleteMapping("/genres/{genreId}")
+    public ResponseEntity<Object> deleteGenre(
+        @PathVariable Long genreId
+    ){
+
+        genreService.delete(genreId);
+
+        return ResponseEntity.noContent().build();
+    }
+
     // 시리즈 추가
     @PostMapping("/series")
     public ResponseEntity<Object> postSeries(@RequestBody @Valid SeriesReq.PostReq req) {
@@ -222,5 +310,27 @@ public class AdminController {
         List<SeriesRes> seriesList = seriesService.getSeries();
 
         return ResponseEntity.ok(seriesList);
+    }
+
+    // 시리즈 수정
+    @PatchMapping("/series/{seriesId}")
+    public ResponseEntity<Object> patchSeries(
+        @PathVariable Long seriesId, @RequestBody @Valid SeriesReq.PatchReq req
+    ){
+
+        seriesService.update(seriesId, req.getTitle());
+
+        return ResponseEntity.noContent().build();
+    }
+
+    // 시리즈 삭제
+    @DeleteMapping("/series/{seriesId}")
+    public ResponseEntity<Object> deleteSeries(
+        @PathVariable Long seriesId
+    ){
+
+        seriesService.delete(seriesId);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/io/oduck/api/domain/genre/dto/GenreReq.java
+++ b/src/main/java/io/oduck/api/domain/genre/dto/GenreReq.java
@@ -13,8 +13,18 @@ public class GenreReq {
     @NoArgsConstructor
     public static class PostReq {
         @NotBlank
-        @Length(min = 1, max = 50,
-                message = "글자 수는 0~50을 허용합니다.")
+        @Length(min = 1, max = 15,
+                message = "글자 수는 1~15을 허용합니다.")
+        private String name;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class PatchReq {
+        @NotBlank
+        @Length(min = 1, max = 15,
+            message = "글자 수는 1~15을 허용합니다.")
         private String name;
     }
 }

--- a/src/main/java/io/oduck/api/domain/genre/entity/Genre.java
+++ b/src/main/java/io/oduck/api/domain/genre/entity/Genre.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,4 +24,12 @@ public class Genre extends BaseEntity {
 
   @Column(nullable = false, length = 15, unique = true)
   private String name;
+
+  public void update(String name) {
+    this.name = name;
+  }
+
+  public void delete() {
+    this.deletedAt = LocalDateTime.now();
+  }
 }

--- a/src/main/java/io/oduck/api/domain/genre/repository/GenreRepository.java
+++ b/src/main/java/io/oduck/api/domain/genre/repository/GenreRepository.java
@@ -1,9 +1,15 @@
 package io.oduck.api.domain.genre.repository;
 
 import io.oduck.api.domain.genre.entity.Genre;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GenreRepository extends JpaRepository<Genre, Long> {
 
   boolean existsByName(String name);
+
+  Optional<Genre> findByIdAndDeletedAtIsNull(Long genreId);
+
+  List<Genre> findAllByDeletedAtIsNull();
 }

--- a/src/main/java/io/oduck/api/domain/genre/service/GenreService.java
+++ b/src/main/java/io/oduck/api/domain/genre/service/GenreService.java
@@ -1,14 +1,17 @@
 package io.oduck.api.domain.genre.service;
 
-import io.oduck.api.domain.genre.dto.GenreRes;
-
-import java.util.List;
-
 import static io.oduck.api.domain.genre.dto.GenreReq.PostReq;
+
+import io.oduck.api.domain.genre.dto.GenreRes;
+import java.util.List;
 
 public interface GenreService {
 
     void save(PostReq req);
 
     List<GenreRes> getGenres();
+
+    void update(Long genreId, String name);
+
+    void delete(Long genreId);
 }

--- a/src/main/java/io/oduck/api/domain/genre/service/GenreServiceImpl.java
+++ b/src/main/java/io/oduck/api/domain/genre/service/GenreServiceImpl.java
@@ -6,6 +6,7 @@ import io.oduck.api.domain.genre.dto.GenreRes;
 import io.oduck.api.domain.genre.entity.Genre;
 import io.oduck.api.domain.genre.repository.GenreRepository;
 import io.oduck.api.global.exception.ConflictException;
+import io.oduck.api.global.exception.NotFoundException;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -40,8 +41,27 @@ public class GenreServiceImpl implements GenreService{
     @Override
     @Transactional(readOnly = true)
     public List<GenreRes> getGenres() {
-        return genreRepository.findAll().stream()
+        return genreRepository.findAllByDeletedAtIsNull().stream()
                 .map(gr -> new GenreRes(gr.getId(), gr.getName()))
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public void update(Long genreId, String name) {
+        Genre genre = findById(genreId);
+
+        genre.update(name);
+    }
+
+    @Override
+    public void delete(Long genreId) {
+        Genre genre = findById(genreId);
+
+        genre.delete();
+    }
+
+    private Genre findById(Long genreId) {
+        return genreRepository.findByIdAndDeletedAtIsNull(genreId)
+            .orElseThrow(() -> new NotFoundException("genre"));
     }
 }

--- a/src/main/java/io/oduck/api/domain/originalAuthor/dto/OriginalAuthorReq.java
+++ b/src/main/java/io/oduck/api/domain/originalAuthor/dto/OriginalAuthorReq.java
@@ -14,7 +14,17 @@ public class OriginalAuthorReq {
     public static class PostReq {
         @NotBlank
         @Length(min = 1, max = 50,
-        message = "글자 수는 0~50을 허용합니다.")
+            message = "글자 수는 1~50을 허용합니다.")
+        private String name;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class PatchReq {
+        @NotBlank
+        @Length(min = 1, max = 50,
+            message = "글자 수는 1~50을 허용합니다.")
         private String name;
     }
 }

--- a/src/main/java/io/oduck/api/domain/originalAuthor/entity/OriginalAuthor.java
+++ b/src/main/java/io/oduck/api/domain/originalAuthor/entity/OriginalAuthor.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,4 +24,12 @@ public class OriginalAuthor extends BaseEntity {
 
   @Column(nullable = false, length = 50, unique = true)
   private String name;
+
+  public void update(String name) {
+    this.name = name;
+  }
+
+  public void delete() {
+    this.deletedAt = LocalDateTime.now();
+  }
 }

--- a/src/main/java/io/oduck/api/domain/originalAuthor/repository/OriginalAuthorRepository.java
+++ b/src/main/java/io/oduck/api/domain/originalAuthor/repository/OriginalAuthorRepository.java
@@ -1,9 +1,16 @@
 package io.oduck.api.domain.originalAuthor.repository;
 
+import com.querydsl.core.Fetchable;
 import io.oduck.api.domain.originalAuthor.entity.OriginalAuthor;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OriginalAuthorRepository extends JpaRepository<OriginalAuthor, Long> {
 
   boolean existsByName(String name);
+
+  Optional<OriginalAuthor> findByIdAndDeletedAtIsNull(Long originalAuthorId);
+
+  List<OriginalAuthor> findAllByDeletedAtIsNull();
 }

--- a/src/main/java/io/oduck/api/domain/originalAuthor/service/OriginalAuthorService.java
+++ b/src/main/java/io/oduck/api/domain/originalAuthor/service/OriginalAuthorService.java
@@ -11,4 +11,8 @@ public interface OriginalAuthorService {
     void save(PostReq req);
 
     List<OriginalAuthorRes> getOriginalAuthors();
+
+    void update(Long originalAuthorId, String name);
+
+    void delete(Long originalAuthorId);
 }

--- a/src/main/java/io/oduck/api/domain/originalAuthor/service/OriginalAuthorServiceImpl.java
+++ b/src/main/java/io/oduck/api/domain/originalAuthor/service/OriginalAuthorServiceImpl.java
@@ -5,7 +5,9 @@ import static io.oduck.api.domain.originalAuthor.dto.OriginalAuthorReq.PostReq;
 import io.oduck.api.domain.originalAuthor.dto.OriginalAuthorRes;
 import io.oduck.api.domain.originalAuthor.entity.OriginalAuthor;
 import io.oduck.api.domain.originalAuthor.repository.OriginalAuthorRepository;
+import io.oduck.api.domain.voiceActor.entity.VoiceActor;
 import io.oduck.api.global.exception.ConflictException;
+import io.oduck.api.global.exception.NotFoundException;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -41,8 +43,27 @@ public class OriginalAuthorServiceImpl implements OriginalAuthorService{
     @Transactional(readOnly = true)
     public List<OriginalAuthorRes> getOriginalAuthors() {
 
-        return originalAuthorRepository.findAll().stream()
+        return originalAuthorRepository.findAllByDeletedAtIsNull().stream()
                 .map(oa -> new OriginalAuthorRes(oa.getId(), oa.getName()))
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public void update(Long originalAuthorId, String name) {
+        OriginalAuthor originalAuthor = findById(originalAuthorId);
+
+        originalAuthor.update(name);
+    }
+
+    @Override
+    public void delete(Long originalAuthorId) {
+        OriginalAuthor originalAuthor = findById(originalAuthorId);
+
+        originalAuthor.delete();
+    }
+
+    private OriginalAuthor findById(Long originalAuthorId) {
+        return originalAuthorRepository.findByIdAndDeletedAtIsNull(originalAuthorId)
+            .orElseThrow(() -> new NotFoundException("originalAuthor"));
     }
 }

--- a/src/main/java/io/oduck/api/domain/series/dto/SeriesReq.java
+++ b/src/main/java/io/oduck/api/domain/series/dto/SeriesReq.java
@@ -14,7 +14,17 @@ public class SeriesReq {
     public static class PostReq {
         @NotBlank
         @Length(min = 1, max = 50,
-                message = "글자 수는 0~50을 허용합니다.")
+            message = "글자 수는 1~50을 허용합니다.")
+        private String title;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class PatchReq {
+        @NotBlank
+        @Length(min = 1, max = 50,
+            message = "글자 수는 1~50을 허용합니다.")
         private String title;
     }
 }

--- a/src/main/java/io/oduck/api/domain/series/entity/Series.java
+++ b/src/main/java/io/oduck/api/domain/series/entity/Series.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,4 +24,12 @@ public class Series extends BaseEntity {
 
   @Column(nullable = false, length = 50, unique = true)
   private String title;
+
+  public void update(String title) {
+    this.title = title;
+  }
+
+  public void delete() {
+    this.deletedAt = LocalDateTime.now();
+  }
 }

--- a/src/main/java/io/oduck/api/domain/series/repository/SeriesRepository.java
+++ b/src/main/java/io/oduck/api/domain/series/repository/SeriesRepository.java
@@ -1,9 +1,15 @@
 package io.oduck.api.domain.series.repository;
 
 import io.oduck.api.domain.series.entity.Series;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SeriesRepository extends JpaRepository<Series, Long> {
 
   boolean existsByTitle(String title);
+
+  Optional<Series> findByIdAndDeletedAtIsNull(Long seriesId);
+
+  List<Series> findAllByDeletedAtIsNull();
 }

--- a/src/main/java/io/oduck/api/domain/series/service/SeriesService.java
+++ b/src/main/java/io/oduck/api/domain/series/service/SeriesService.java
@@ -1,14 +1,17 @@
 package io.oduck.api.domain.series.service;
 
-import io.oduck.api.domain.series.dto.SeriesRes;
-
-import java.util.List;
-
 import static io.oduck.api.domain.series.dto.SeriesReq.PostReq;
+
+import io.oduck.api.domain.series.dto.SeriesRes;
+import java.util.List;
 
 public interface SeriesService {
 
     void save(PostReq req);
 
     List<SeriesRes> getSeries();
+
+    void update(Long seriesId, String title);
+
+    void delete(Long seriesId);
 }

--- a/src/main/java/io/oduck/api/domain/series/service/SeriesServiceImpl.java
+++ b/src/main/java/io/oduck/api/domain/series/service/SeriesServiceImpl.java
@@ -5,7 +5,9 @@ import static io.oduck.api.domain.series.dto.SeriesReq.PostReq;
 import io.oduck.api.domain.series.dto.SeriesRes;
 import io.oduck.api.domain.series.entity.Series;
 import io.oduck.api.domain.series.repository.SeriesRepository;
+import io.oduck.api.domain.voiceActor.entity.VoiceActor;
 import io.oduck.api.global.exception.ConflictException;
+import io.oduck.api.global.exception.NotFoundException;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -40,8 +42,27 @@ public class SeriesServiceImpl implements SeriesService{
     @Override
     @Transactional(readOnly = true)
     public List<SeriesRes> getSeries() {
-        return seriesRepository.findAll().stream()
+        return seriesRepository.findAllByDeletedAtIsNull().stream()
                 .map(s -> new SeriesRes(s.getId(), s.getTitle()))
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public void update(Long seriesId, String title) {
+        Series series = findById(seriesId);
+
+        series.update(title);
+    }
+
+    @Override
+    public void delete(Long seriesId) {
+        Series series = findById(seriesId);
+
+        series.delete();
+    }
+
+    private Series findById(Long seriesId) {
+        return seriesRepository.findByIdAndDeletedAtIsNull(seriesId)
+            .orElseThrow(() -> new NotFoundException("series"));
     }
 }

--- a/src/main/java/io/oduck/api/domain/studio/dto/StudioReq.java
+++ b/src/main/java/io/oduck/api/domain/studio/dto/StudioReq.java
@@ -14,7 +14,17 @@ public class StudioReq {
     public static class PostReq {
         @NotBlank
         @Length(min = 1, max = 50,
-                message = "글자 수는 0~50을 허용합니다.")
+            message = "글자 수는 1~50을 허용합니다.")
         private String name;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class PatchReq {
+      @NotBlank
+      @Length(min = 1, max = 50,
+          message = "글자 수는 1~50을 허용합니다.")
+      private String name;
     }
 }

--- a/src/main/java/io/oduck/api/domain/studio/entity/Studio.java
+++ b/src/main/java/io/oduck/api/domain/studio/entity/Studio.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,4 +24,12 @@ public class Studio extends BaseEntity {
 
   @Column(nullable = false, length = 50, unique = true)
   private String name;
+
+  public void update(String name) {
+    this.name = name;
+  }
+
+  public void delete() {
+    this.deletedAt = LocalDateTime.now();
+  }
 }

--- a/src/main/java/io/oduck/api/domain/studio/repository/StudioRepository.java
+++ b/src/main/java/io/oduck/api/domain/studio/repository/StudioRepository.java
@@ -1,9 +1,16 @@
 package io.oduck.api.domain.studio.repository;
 
+import com.querydsl.core.Fetchable;
 import io.oduck.api.domain.studio.entity.Studio;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StudioRepository extends JpaRepository<Studio, Long> {
 
   boolean existsByName(String name);
+
+  Optional<Studio> findByIdAndDeletedAtIsNull(Long studioId);
+
+  List<Studio> findAllByDeletedAtIsNull();
 }

--- a/src/main/java/io/oduck/api/domain/studio/service/StudioService.java
+++ b/src/main/java/io/oduck/api/domain/studio/service/StudioService.java
@@ -1,13 +1,16 @@
 package io.oduck.api.domain.studio.service;
 
-import io.oduck.api.domain.studio.dto.StudioRes;
-
-import java.util.List;
-
 import static io.oduck.api.domain.studio.dto.StudioReq.PostReq;
+
+import io.oduck.api.domain.studio.dto.StudioRes;
+import java.util.List;
 
 public interface StudioService {
     void save(PostReq req);
 
     List<StudioRes> getStudios();
+
+    void update(Long studioId, String name);
+
+    void delete(Long studioId);
 }

--- a/src/main/java/io/oduck/api/domain/studio/service/StudioServiceImpl.java
+++ b/src/main/java/io/oduck/api/domain/studio/service/StudioServiceImpl.java
@@ -5,6 +5,7 @@ import io.oduck.api.domain.studio.dto.StudioRes;
 import io.oduck.api.domain.studio.entity.Studio;
 import io.oduck.api.domain.studio.repository.StudioRepository;
 import io.oduck.api.global.exception.ConflictException;
+import io.oduck.api.global.exception.NotFoundException;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -39,8 +40,27 @@ public class StudioServiceImpl implements StudioService{
     @Override
     @Transactional(readOnly = true)
     public List<StudioRes> getStudios() {
-        return studioRepository.findAll().stream()
+        return studioRepository.findAllByDeletedAtIsNull().stream()
                 .map(st -> new StudioRes(st.getId(), st.getName()))
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public void update(Long studioId, String name) {
+        Studio studio = findById(studioId);
+
+        studio.update(name);
+    }
+
+    @Override
+    public void delete(Long studioId) {
+        Studio studio = findById(studioId);
+
+        studio.delete();
+    }
+
+    private Studio findById(Long studioId) {
+        return studioRepository.findByIdAndDeletedAtIsNull(studioId)
+            .orElseThrow(() -> new NotFoundException("studio"));
     }
 }

--- a/src/main/java/io/oduck/api/domain/voiceActor/dto/VoiceActorReq.java
+++ b/src/main/java/io/oduck/api/domain/voiceActor/dto/VoiceActorReq.java
@@ -17,4 +17,14 @@ public class VoiceActorReq {
                 message = "글자 수는 0~50을 허용합니다.")
         private String name;
     }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class PatchReq {
+        @NotBlank
+        @Length(min = 1, max = 50,
+            message = "글자 수는 1~50을 허용합니다.")
+        private String name;
+    }
 }

--- a/src/main/java/io/oduck/api/domain/voiceActor/entity/VoiceActor.java
+++ b/src/main/java/io/oduck/api/domain/voiceActor/entity/VoiceActor.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,4 +24,12 @@ public class VoiceActor extends BaseEntity {
 
   @Column(nullable = false, length = 50, unique = true)
   private String name;
+
+  public void update(String name) {
+    this.name = name;
+  }
+
+  public void delete() {
+    this.deletedAt = LocalDateTime.now();
+  }
 }

--- a/src/main/java/io/oduck/api/domain/voiceActor/repository/VoiceActorRepository.java
+++ b/src/main/java/io/oduck/api/domain/voiceActor/repository/VoiceActorRepository.java
@@ -1,9 +1,15 @@
 package io.oduck.api.domain.voiceActor.repository;
 
 import io.oduck.api.domain.voiceActor.entity.VoiceActor;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface VoiceActorRepository extends JpaRepository<VoiceActor, Long> {
 
   boolean existsByName(String name);
+
+  List<VoiceActor> findAllByDeletedAtIsNull();
+
+  Optional<VoiceActor> findByIdAndDeletedAtIsNull(Long voiceActorId);
 }

--- a/src/main/java/io/oduck/api/domain/voiceActor/service/VoiceActorService.java
+++ b/src/main/java/io/oduck/api/domain/voiceActor/service/VoiceActorService.java
@@ -12,4 +12,7 @@ public interface VoiceActorService {
 
     List<VoiceActorRes> getVoiceActors();
 
+    void update(Long voiceActorId, String name);
+
+    void delete(Long voiceActorId);
 }

--- a/src/main/java/io/oduck/api/domain/voiceActor/service/VoiceActorServiceImpl.java
+++ b/src/main/java/io/oduck/api/domain/voiceActor/service/VoiceActorServiceImpl.java
@@ -6,6 +6,7 @@ import io.oduck.api.domain.voiceActor.dto.VoiceActorRes;
 import io.oduck.api.domain.voiceActor.entity.VoiceActor;
 import io.oduck.api.domain.voiceActor.repository.VoiceActorRepository;
 import io.oduck.api.global.exception.ConflictException;
+import io.oduck.api.global.exception.NotFoundException;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -40,8 +41,27 @@ public class VoiceActorServiceImpl implements VoiceActorService{
     @Override
     @Transactional(readOnly = true)
     public List<VoiceActorRes> getVoiceActors() {
-        return voiceActorRepository.findAll().stream()
+        return voiceActorRepository.findAllByDeletedAtIsNull().stream()
                 .map(va -> new VoiceActorRes(va.getId(), va.getName()))
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public void update(Long voiceActorId, String name) {
+        VoiceActor voiceActor = findById(voiceActorId);
+
+        voiceActor.update(name);
+    }
+
+    @Override
+    public void delete(Long voiceActorId) {
+        VoiceActor voiceActor = findById(voiceActorId);
+
+        voiceActor.delete();
+    }
+
+    private VoiceActor findById(Long voiceActorId) {
+        return voiceActorRepository.findByIdAndDeletedAtIsNull(voiceActorId)
+            .orElseThrow(() -> new NotFoundException("voiceActor"));
     }
 }

--- a/src/test/java/io/oduck/api/e2e/admin/AdminControllerTest.java
+++ b/src/test/java/io/oduck/api/e2e/admin/AdminControllerTest.java
@@ -5,6 +5,7 @@ import io.oduck.api.domain.anime.dto.AnimeReq.*;
 import io.oduck.api.domain.anime.dto.AnimeVoiceActorReq;
 import io.oduck.api.domain.genre.dto.GenreReq;
 import io.oduck.api.domain.originalAuthor.dto.OriginalAuthorReq;
+import io.oduck.api.domain.originalAuthor.dto.OriginalAuthorReq.PatchReq;
 import io.oduck.api.domain.series.dto.SeriesReq;
 import io.oduck.api.domain.studio.dto.StudioReq;
 import io.oduck.api.domain.voiceActor.dto.VoiceActorReq;
@@ -540,6 +541,65 @@ public class AdminControllerTest {
                     )
                 ));
         }
+
+        @Test
+        @DisplayName("수정 성공 시 Http Status 204 반환")
+        void patchOriginalAuthor() throws Exception {
+            //given
+            Long originalAuthorId = 1L;
+            OriginalAuthorReq.PatchReq req = new PatchReq("원작 작가 수정");
+            String content = gson.toJson(req);
+
+            //when
+            ResultActions actions = mockMvc.perform(
+                patch(ADMIN_URL+"/original-authors/{originalAuthorId}", originalAuthorId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .content(content)
+            );
+
+            //then
+            actions
+                .andExpect(status().isNoContent())
+                .andDo(document("patchOriginalAuthor/success",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("originalAuthorId").description("원작 작가의 식별자")
+                    ),
+                    requestFields(attributes(key("title").value("Fields for original author creation")),
+                        fieldWithPath("name")
+                            .type(JsonFieldType.STRING)
+                            .attributes(field("constraints", "공백을 허용하지 않습니다. 1~50자를 허용합니다."))
+                            .description("원작 작가의 이름")
+                    )
+                ));
+        }
+
+        @Test
+        @DisplayName("삭제 성공 시 Http Status 204 반환")
+        void deleteOriginalAuthor() throws Exception {
+            //given
+            Long originalAuthorId = 1L;
+
+            //when
+            ResultActions actions = mockMvc.perform(
+                delete(ADMIN_URL+"/original-authors/{originalAuthorId}", originalAuthorId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+            );
+
+            //then
+            actions
+                .andExpect(status().isNoContent())
+                .andDo(document("deleteOriginalAuthor/success",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("originalAuthorId").description("원작 작가의 식별자")
+                    )
+                ));
+        }
     }
 
     @Nested
@@ -627,6 +687,65 @@ public class AdminControllerTest {
                             .type(JsonFieldType.STRING)
                             .attributes(field("constraints", "공백을 허용하지 않습니다. 1~50자를 허용합니다."))
                             .description("성우의 이름")
+                    )
+                ));
+        }
+
+        @Test
+        @DisplayName("수정 성공 시 Http Status 204 반환")
+        void patchVoiceActor() throws Exception {
+            //given
+            Long voiceActorId = 1L;
+            VoiceActorReq.PatchReq req = new VoiceActorReq.PatchReq("성우 수정");
+            String content = gson.toJson(req);
+
+            //when
+            ResultActions actions = mockMvc.perform(
+                patch(ADMIN_URL+"/voice-actors/{voiceActorId}", voiceActorId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .content(content)
+            );
+
+            //then
+            actions
+                .andExpect(status().isNoContent())
+                .andDo(document("patchVoiceActor/success",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("voiceActorId").description("성우의 식별자")
+                    ),
+                    requestFields(attributes(key("title").value("Fields for voice actor creation")),
+                        fieldWithPath("name")
+                            .type(JsonFieldType.STRING)
+                            .attributes(field("constraints", "공백을 허용하지 않습니다. 1~50자를 허용합니다."))
+                            .description("성우의 이름")
+                    )
+                ));
+        }
+
+        @Test
+        @DisplayName("삭제 성공 시 Http Status 204 반환")
+        void deleteVoiceActor() throws Exception {
+            //given
+            Long voiceActorId = 1L;
+
+            //when
+            ResultActions actions = mockMvc.perform(
+                delete(ADMIN_URL+"/voice-actors/{voiceActorId}", voiceActorId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+            );
+
+            //then
+            actions
+                .andExpect(status().isNoContent())
+                .andDo(document("deleteVoiceActor/success",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("voiceActorId").description("성우의 식별자")
                     )
                 ));
         }
@@ -720,6 +839,65 @@ public class AdminControllerTest {
                     )
                 ));
         }
+
+        @Test
+        @DisplayName("수정 성공 시 Http Status 204 반환")
+        void patchStudio() throws Exception {
+            //given
+            Long studioId = 1L;
+            StudioReq.PatchReq req = new StudioReq.PatchReq("스튜디오 수정");
+            String content = gson.toJson(req);
+
+            //when
+            ResultActions actions = mockMvc.perform(
+                patch(ADMIN_URL+"/studios/{studioId}", studioId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .content(content)
+            );
+
+            //then
+            actions
+                .andExpect(status().isNoContent())
+                .andDo(document("patchStudio/success",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("studioId").description("스튜디오의 식별자")
+                    ),
+                    requestFields(attributes(key("title").value("Fields for studio creation")),
+                        fieldWithPath("name")
+                            .type(JsonFieldType.STRING)
+                            .attributes(field("constraints", "공백을 허용하지 않습니다. 1~50자를 허용합니다."))
+                            .description("스튜디오의 이름")
+                    )
+                ));
+        }
+
+        @Test
+        @DisplayName("삭제 성공 시 Http Status 204 반환")
+        void deleteStudio() throws Exception {
+            //given
+            Long studioId = 1L;
+
+            //when
+            ResultActions actions = mockMvc.perform(
+                delete(ADMIN_URL+"/studios/{studioId}", studioId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+            );
+
+            //then
+            actions
+                .andExpect(status().isNoContent())
+                .andDo(document("deleteStudio/success",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("studioId").description("스튜디오의 식별자")
+                    )
+                ));
+        }
     }
 
 
@@ -755,7 +933,7 @@ public class AdminControllerTest {
 
         @Test
         @DisplayName("등록 성공 시 Http Status 204 반환")
-        void postVoiceActor() throws Exception {
+        void postGenre() throws Exception {
             String name = "이세계";
             GenreReq.PostReq postReq = new GenreReq.PostReq(name);
             String content = gson.toJson(postReq);
@@ -808,6 +986,65 @@ public class AdminControllerTest {
                             .type(JsonFieldType.STRING)
                             .attributes(field("constraints", "공백을 허용하지 않습니다. 1~15자를 허용합니다."))
                             .description("장르의 이름")
+                    )
+                ));
+        }
+
+        @Test
+        @DisplayName("수정 성공 시 Http Status 204 반환")
+        void patchGenre() throws Exception {
+            //given
+            Long genreId = 1L;
+            GenreReq.PatchReq req = new GenreReq.PatchReq("장르 수정");
+            String content = gson.toJson(req);
+
+            //when
+            ResultActions actions = mockMvc.perform(
+                patch(ADMIN_URL+"/genres/{genreId}", genreId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .content(content)
+            );
+
+            //then
+            actions
+                .andExpect(status().isNoContent())
+                .andDo(document("patchGenre/success",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("genreId").description("장르의 식별자")
+                    ),
+                    requestFields(attributes(key("title").value("Fields for studio creation")),
+                        fieldWithPath("name")
+                            .type(JsonFieldType.STRING)
+                            .attributes(field("constraints", "공백을 허용하지 않습니다. 1~15자를 허용합니다."))
+                            .description("장르의 이름")
+                    )
+                ));
+        }
+
+        @Test
+        @DisplayName("삭제 성공 시 Http Status 204 반환")
+        void deleteGenre() throws Exception {
+            //given
+            Long genreId = 1L;
+
+            //when
+            ResultActions actions = mockMvc.perform(
+                delete(ADMIN_URL+"/genres/{genreId}", genreId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+            );
+
+            //then
+            actions
+                .andExpect(status().isNoContent())
+                .andDo(document("deleteGenre/success",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("genreId").description("장르의 식별자")
                     )
                 ));
         }
@@ -899,6 +1136,65 @@ public class AdminControllerTest {
                             .type(JsonFieldType.STRING)
                             .attributes(field("constraints", "공백을 허용하지 않습니다. 1~50자를 허용합니다."))
                             .description("시리즈의 제목")
+                    )
+                ));
+        }
+
+        @Test
+        @DisplayName("수정 성공 시 Http Status 204 반환")
+        void patchSeries() throws Exception {
+            //given
+            Long seriesId = 1L;
+            SeriesReq.PatchReq req = new SeriesReq.PatchReq("시리즈 수정");
+            String content = gson.toJson(req);
+
+            //when
+            ResultActions actions = mockMvc.perform(
+                patch(ADMIN_URL+"/series/{seriesId}", seriesId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .content(content)
+            );
+
+            //then
+            actions
+                .andExpect(status().isNoContent())
+                .andDo(document("patchSeries/success",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("seriesId").description("시리즈의 식별자")
+                    ),
+                    requestFields(attributes(key("title").value("Fields for studio creation")),
+                        fieldWithPath("title")
+                            .type(JsonFieldType.STRING)
+                            .attributes(field("constraints", "공백을 허용하지 않습니다. 1~50자를 허용합니다."))
+                            .description("시리즈의 이름")
+                    )
+                ));
+        }
+
+        @Test
+        @DisplayName("삭제 성공 시 Http Status 204 반환")
+        void deleteSeries() throws Exception {
+            //given
+            Long seriesId = 1L;
+
+            //when
+            ResultActions actions = mockMvc.perform(
+                delete(ADMIN_URL+"/series/{seriesId}", seriesId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+            );
+
+            //then
+            actions
+                .andExpect(status().isNoContent())
+                .andDo(document("deleteSeries/success",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("seriesId").description("시리즈의 식별자")
                     )
                 ));
         }

--- a/src/test/java/io/oduck/api/unit/genre/service/GenreServiceTest.java
+++ b/src/test/java/io/oduck/api/unit/genre/service/GenreServiceTest.java
@@ -57,7 +57,7 @@ public class GenreServiceTest {
             assertThatNoException();
 
             //verify
-            verify(genreRepository, times(1)).findAll();
+            verify(genreRepository, times(1)).findAllByDeletedAtIsNull();
         }
     }
 }

--- a/src/test/java/io/oduck/api/unit/originalAuthor/service/OriginalAuthorServiceTest.java
+++ b/src/test/java/io/oduck/api/unit/originalAuthor/service/OriginalAuthorServiceTest.java
@@ -59,7 +59,7 @@ public class OriginalAuthorServiceTest {
             assertThatNoException();
 
             //verify
-            verify(originalAuthorRepository, times(1)).findAll();
+            verify(originalAuthorRepository, times(1)).findAllByDeletedAtIsNull();
         }
     }
 }

--- a/src/test/java/io/oduck/api/unit/series/service/SeriesServiceTest.java
+++ b/src/test/java/io/oduck/api/unit/series/service/SeriesServiceTest.java
@@ -58,7 +58,7 @@ public class SeriesServiceTest {
             assertThatNoException();
 
             //verify
-            verify(seriesRepository, times(1)).findAll();
+            verify(seriesRepository, times(1)).findAllByDeletedAtIsNull();
         }
     }
 }

--- a/src/test/java/io/oduck/api/unit/studio/service/StudioServiceTest.java
+++ b/src/test/java/io/oduck/api/unit/studio/service/StudioServiceTest.java
@@ -58,7 +58,7 @@ public class StudioServiceTest {
             assertThatNoException();
 
             //verify
-            verify(studioRepository, times(1)).findAll();
+            verify(studioRepository, times(1)).findAllByDeletedAtIsNull();
         }
     }
 }

--- a/src/test/java/io/oduck/api/unit/voiceActor/service/VoiceActorServiceTest.java
+++ b/src/test/java/io/oduck/api/unit/voiceActor/service/VoiceActorServiceTest.java
@@ -59,7 +59,7 @@ public class VoiceActorServiceTest {
             assertThatNoException();
 
             //verify
-            verify(voiceActorRepository, times(1)).findAll();
+            verify(voiceActorRepository, times(1)).findAllByDeletedAtIsNull();
         }
     }
 }


### PR DESCRIPTION
## 📝 개요
애니 관련 도메인(원작 작가, 성우, 스튜디오, 장르, 시리즈)의 수정, 삭제 구현

## 🚀 변경사항
- 애니 관련 도메인 수정, 삭제 구현
- 문서화

## 🔗 관련 이슈
#63 