### PR TITLE
github pr 및 push시 빌드 성공후 docker hub push #86

### DIFF
--- a/.github/workflows/dev_ci.yml
+++ b/.github/workflows/dev_ci.yml
@@ -5,16 +5,14 @@
 # This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
 
-name: server_ci
+name: server_dev_ci
 
 on:
   push:
     branches:
-      - main
       - develop
   pull_request:
     branches:
-      - main
       - develop
 
 permissions:
@@ -45,3 +43,16 @@ jobs:
           aws_access_key: ${{ secrets.AWS_ACCESS_KEY }}
           aws_secret_key: ${{ secrets.AWS_SECRET_KEY }}
           aws_region: ${{ secrets.AWs_REGION }}
+
+      - name: docker image build
+        run: docker buildx build --platform linux/amd64 -f ./dockerfile-dev -t ${{ secrets.DOCKERHUB_USERNAME }}/oduckio-spring .
+
+      - name: docker login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: docker Hub push
+        run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/oduckio-spring
+

--- a/.github/workflows/dev_ci.yml
+++ b/.github/workflows/dev_ci.yml
@@ -45,7 +45,7 @@ jobs:
           aws_region: ${{ secrets.AWs_REGION }}
 
       - name: docker image build
-        run: docker buildx build --platform linux/amd64 -f ./dockerfile-dev -t ${{ secrets.DOCKERHUB_USERNAME }}/oduckio-spring .
+        run: docker build -f dockerfile-dev -t ${{ secrets.DOCKERHUB_USERNAME }}/oduckio-spring .
 
       - name: docker login
         uses: docker/login-action@v2

--- a/.github/workflows/prod_ci.yml
+++ b/.github/workflows/prod_ci.yml
@@ -1,0 +1,58 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+
+name: server_prod_ci
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    services:
+      redis:
+        image: redis:latest
+        ports:
+          - 6379:6379
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25 # v2.6.0
+        with:
+          arguments: build
+        env:
+          aws_access_key: ${{ secrets.AWS_ACCESS_KEY }}
+          aws_secret_key: ${{ secrets.AWS_SECRET_KEY }}
+          aws_region: ${{ secrets.AWs_REGION }}
+
+      - name: docker image build
+        run: docker buildx build --platform linux/amd64 -f ./dockerfile-prod -t ${{ secrets.DOCKERHUB_USERNAME }}/oduckio-spring:${{ secrets.PROD_VERSION }} .
+
+      - name: docker login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: docker Hub push
+        run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/oduckio-spring:${{ secrets.PROD_VERSION }}
+

--- a/.github/workflows/prod_ci.yml
+++ b/.github/workflows/prod_ci.yml
@@ -45,7 +45,7 @@ jobs:
           aws_region: ${{ secrets.AWs_REGION }}
 
       - name: docker image build
-        run: docker buildx build --platform linux/amd64 -f ./dockerfile-prod -t ${{ secrets.DOCKERHUB_USERNAME }}/oduckio-spring:${{ secrets.PROD_VERSION }} .
+        run: docker build -f dockerfile-dev -t ${{ secrets.DOCKERHUB_USERNAME }}/oduckio-spring:${{ secrets.PROD_VERSION }} .
 
       - name: docker login
         uses: docker/login-action@v2


### PR DESCRIPTION
## 📝 개요
github pr 및 push시 빌드 성공후 docker hub push #86

## 🚀 변경사항
- dev, prod ci 분리
- 빌드 성공후 docker hub push 추가

## 🔗 관련 이슈
#86 