### PR TITLE
별점 평가 여부 조회시 점수도 포함하도록 수정 #103

### DIFF
--- a/src/main/java/io/oduck/api/domain/starRating/dto/StarRatingResDto.java
+++ b/src/main/java/io/oduck/api/domain/starRating/dto/StarRatingResDto.java
@@ -10,7 +10,8 @@ public class StarRatingResDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class RatedDateTimeRes {
+    public static class RatedRes {
+        private int score;
         private String createdAt;
     }
 

--- a/src/main/java/io/oduck/api/domain/starRating/service/StarRatingService.java
+++ b/src/main/java/io/oduck/api/domain/starRating/service/StarRatingService.java
@@ -1,9 +1,9 @@
 package io.oduck.api.domain.starRating.service;
 
-import io.oduck.api.domain.starRating.dto.StarRatingResDto.RatedDateTimeRes;
+import io.oduck.api.domain.starRating.dto.StarRatingResDto.RatedRes;
 
 public interface StarRatingService {
     boolean createScore(Long memberId, Long animeId, int score);
-    RatedDateTimeRes checkRated(Long memberId, Long animeId);
+    RatedRes checkRated(Long memberId, Long animeId);
     boolean updateScore(Long memberId, Long animeId, int score);
 }

--- a/src/main/java/io/oduck/api/domain/starRating/service/StarRatingServiceImpl.java
+++ b/src/main/java/io/oduck/api/domain/starRating/service/StarRatingServiceImpl.java
@@ -4,7 +4,7 @@ import io.oduck.api.domain.anime.entity.Anime;
 import io.oduck.api.domain.anime.repository.AnimeRepository;
 import io.oduck.api.domain.member.entity.Member;
 import io.oduck.api.domain.member.repository.MemberRepository;
-import io.oduck.api.domain.starRating.dto.StarRatingResDto.RatedDateTimeRes;
+import io.oduck.api.domain.starRating.dto.StarRatingResDto.RatedRes;
 import io.oduck.api.domain.starRating.entity.StarRating;
 import io.oduck.api.domain.starRating.repository.StarRatingRepository;
 import io.oduck.api.global.exception.NotFoundException;
@@ -49,11 +49,12 @@ public class StarRatingServiceImpl implements StarRatingService {
     }
 
     @Override
-    public RatedDateTimeRes checkRated(Long memberId, Long animeId) {
+    public RatedRes checkRated(Long memberId, Long animeId) {
         StarRating foundStarRating = findByMemberIdAndAnimeId(memberId, animeId)
             .orElseThrow(() -> new NotFoundException("StarRating"));
 
-        return RatedDateTimeRes.builder()
+        return RatedRes.builder()
+            .score(foundStarRating.getScore())
             .createdAt(foundStarRating.getCreatedAt().toString())
             .build();
     }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -104,9 +104,9 @@ logging:
     name: ./logs/oDuck.log
   logback:
     rollingpolicy:
-      max-file-size: 10MB #default 10MB
-      max-history: 30 #default 7
-      file-name-pattern: oDuck.%d{yyyy-MM-dd}.%i.gz
+      max-file-size: 10MB   #default 10MB
+      max-history: 30       #default 7
+      file-name-pattern: ./logs/oDuck.%d{yyyy-MM-dd}.%i.gz
 
 config:
   base:

--- a/src/test/java/io/oduck/api/e2e/starRating/StarRatingControllerTest.java
+++ b/src/test/java/io/oduck/api/e2e/starRating/StarRatingControllerTest.java
@@ -197,6 +197,8 @@ public class StarRatingControllerTest {
                         responseFields(
                             attributes(key("title")
                                 .value("Fields for starRating get")),
+                            fieldWithPath("score")
+                                .description("별점 점수"),
                             fieldWithPath("createdAt")
                                 .description("별점 생성일")
                         )

--- a/src/test/java/io/oduck/api/unit/starRating/service/StarRatingServiceTest.java
+++ b/src/test/java/io/oduck/api/unit/starRating/service/StarRatingServiceTest.java
@@ -1,6 +1,7 @@
 package io.oduck.api.unit.starRating.service;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -11,7 +12,7 @@ import io.oduck.api.domain.anime.entity.Anime;
 import io.oduck.api.domain.anime.repository.AnimeRepository;
 import io.oduck.api.domain.member.entity.Member;
 import io.oduck.api.domain.member.repository.MemberRepository;
-import io.oduck.api.domain.starRating.dto.StarRatingResDto.RatedDateTimeRes;
+import io.oduck.api.domain.starRating.dto.StarRatingResDto.RatedRes;
 import io.oduck.api.domain.starRating.entity.StarRating;
 import io.oduck.api.domain.starRating.repository.StarRatingRepository;
 import io.oduck.api.domain.starRating.service.StarRatingServiceImpl;
@@ -125,14 +126,12 @@ public class StarRatingServiceTest {
                 .willReturn(Optional.ofNullable(starRating));
 
             // when
-            StarRating foundStarRating = starRatingRepository.findByMemberIdAndAnimeId(memberId, animeId)
-                .orElseThrow(() -> new RuntimeException("StarRating"));
-
-            RatedDateTimeRes createdAtScore = starRatingService.checkRated(memberId, animeId);
+            RatedRes foundStarRating = starRatingService.checkRated(memberId, animeId);
 
             // then
             assertDoesNotThrow(() -> starRatingService.checkRated(memberId, animeId));
-            assertNotNull(createdAtScore);
+            assertNotNull(foundStarRating);
+            assertEquals(starRating.getScore(), foundStarRating.getScore());
         }
 
         @DisplayName("별점 조회 실패")


### PR DESCRIPTION
## 📝 개요
별점 평가 여부 조회시 점수도 포함하도록 수정

## 🚀 변경사항
- 별점 여부 조회 dto 별점 추가
- 별점 여부 조회 서비스 별점 추가
- 별점 여부 조회 테스트 별점 추가

## 🔗 관련 이슈
#103