### PR TITLE
장르, 성우, 원작자, 제작사, 시리즈 삭제 수정 #102

### DIFF
--- a/src/main/java/io/oduck/api/domain/admin/controller/AdminController.java
+++ b/src/main/java/io/oduck/api/domain/admin/controller/AdminController.java
@@ -149,6 +149,7 @@ public class AdminController {
 
         return ResponseEntity.noContent().build();
     }
+
     // 애니의 성우 수정
     @PatchMapping("/animes/{animeId}/voice-actors")
     public ResponseEntity<Object> patchAnimeVoiceActors(

--- a/src/main/java/io/oduck/api/domain/anime/dto/AnimeReq.java
+++ b/src/main/java/io/oduck/api/domain/anime/dto/AnimeReq.java
@@ -23,7 +23,7 @@ public class AnimeReq {
         private String title;
 
         @NotBlank
-        @Length(min = 1, max = 255, message = "글자 수는 0~255를 허용합니다.")
+        @Length(min = 1, max = 600, message = "글자 수는 0~255를 허용합니다.")
         private String summary;
 
         @NotNull

--- a/src/main/java/io/oduck/api/domain/anime/dto/AnimeReq.java
+++ b/src/main/java/io/oduck/api/domain/anime/dto/AnimeReq.java
@@ -19,11 +19,11 @@ public class AnimeReq {
     @Getter
     public static class PostReq {
         @NotBlank
-        @Length(min = 1, max = 50, message = "글자 수는 0~50을 허용합니다.")
+        @Length(min = 1, max = 50, message = "글자 수는 1~50을 허용합니다.")
         private String title;
 
         @NotBlank
-        @Length(min = 1, max = 600, message = "글자 수는 0~255를 허용합니다.")
+        @Length(min = 1, max = 600, message = "글자 수는 1~600자를 허용합니다.")
         private String summary;
 
         @NotNull

--- a/src/main/java/io/oduck/api/domain/anime/entity/Anime.java
+++ b/src/main/java/io/oduck/api/domain/anime/entity/Anime.java
@@ -157,6 +157,12 @@ public class Anime extends BaseEntity {
   }
 
   public void delete() {
+    this.animeOriginalAuthors.clear();
+    this.animeVoiceActors.clear();
+    this.animeGenres.clear();
+    this.animeStudios.clear();
+    this.series = null;
+
     this.deletedAt = LocalDateTime.now();
   }
 

--- a/src/main/java/io/oduck/api/domain/genre/entity/Genre.java
+++ b/src/main/java/io/oduck/api/domain/genre/entity/Genre.java
@@ -1,12 +1,17 @@
 package io.oduck.api.domain.genre.entity;
 
+import io.oduck.api.domain.anime.entity.AnimeGenre;
 import io.oduck.api.global.audit.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,14 +27,19 @@ public class Genre extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(nullable = false, length = 15, unique = true)
+  @Column(nullable = false, length = 15)
   private String name;
+
+  @OneToMany(mappedBy = "genre", cascade = CascadeType.PERSIST, orphanRemoval = true)
+  @Builder.Default
+  private List<AnimeGenre> animeGenres = new ArrayList<>();
 
   public void update(String name) {
     this.name = name;
   }
 
   public void delete() {
+    this.animeGenres.clear();
     this.deletedAt = LocalDateTime.now();
   }
 }

--- a/src/main/java/io/oduck/api/domain/genre/repository/GenreRepository.java
+++ b/src/main/java/io/oduck/api/domain/genre/repository/GenreRepository.java
@@ -4,12 +4,15 @@ import io.oduck.api.domain.genre.entity.Genre;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface GenreRepository extends JpaRepository<Genre, Long> {
 
   boolean existsByName(String name);
 
-  Optional<Genre> findByIdAndDeletedAtIsNull(Long genreId);
+  @Query("select distinct g from Genre g join fetch g.animeGenres where g.id = :id")
+  Optional<Genre> findByIdAndDeletedAtIsNull(@Param("id") Long genreId);
 
   List<Genre> findAllByDeletedAtIsNull();
 }

--- a/src/main/java/io/oduck/api/domain/genre/repository/GenreRepository.java
+++ b/src/main/java/io/oduck/api/domain/genre/repository/GenreRepository.java
@@ -7,11 +7,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface GenreRepository extends JpaRepository<Genre, Long> {
+public interface GenreRepository extends JpaRepository<Genre, Long>, GenreRepositoryCustom {
 
-  boolean existsByName(String name);
-
-  @Query("select distinct g from Genre g join fetch g.animeGenres where g.id = :id")
+  @Query("select distinct g from Genre g left join fetch g.animeGenres where g.id = :id and g.deletedAt = null")
   Optional<Genre> findByIdAndDeletedAtIsNull(@Param("id") Long genreId);
 
   List<Genre> findAllByDeletedAtIsNull();

--- a/src/main/java/io/oduck/api/domain/genre/repository/GenreRepositoryCustom.java
+++ b/src/main/java/io/oduck/api/domain/genre/repository/GenreRepositoryCustom.java
@@ -1,0 +1,5 @@
+package io.oduck.api.domain.genre.repository;
+
+public interface GenreRepositoryCustom {
+    boolean existsByName(String name);
+}

--- a/src/main/java/io/oduck/api/domain/genre/repository/GenreRepositoryCustomImpl.java
+++ b/src/main/java/io/oduck/api/domain/genre/repository/GenreRepositoryCustomImpl.java
@@ -1,0 +1,31 @@
+package io.oduck.api.domain.genre.repository;
+
+import static io.oduck.api.domain.genre.entity.QGenre.genre;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class GenreRepositoryCustomImpl implements GenreRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public boolean existsByName(String name) {
+        Integer fetchOne = queryFactory
+            .selectOne()
+            .from(genre)
+            .where(
+                genre.name.eq(name),
+                notDeleted()
+            ).fetchFirst();
+        return fetchOne != null;
+    }
+
+    private BooleanExpression notDeleted() {
+        return genre.deletedAt.isNull();
+    }
+}

--- a/src/main/java/io/oduck/api/domain/originalAuthor/entity/OriginalAuthor.java
+++ b/src/main/java/io/oduck/api/domain/originalAuthor/entity/OriginalAuthor.java
@@ -1,12 +1,18 @@
 package io.oduck.api.domain.originalAuthor.entity;
 
+import io.oduck.api.domain.anime.entity.Anime;
+import io.oduck.api.domain.anime.entity.AnimeOriginalAuthor;
 import io.oduck.api.global.audit.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,14 +28,19 @@ public class OriginalAuthor extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(nullable = false, length = 50, unique = true)
+  @Column(nullable = false, length = 50)
   private String name;
+
+  @OneToMany(mappedBy = "originalAuthor", cascade = CascadeType.PERSIST, orphanRemoval = true)
+  @Builder.Default
+  private List<AnimeOriginalAuthor> animeOriginalAuthors = new ArrayList<>();
 
   public void update(String name) {
     this.name = name;
   }
 
   public void delete() {
+    this.animeOriginalAuthors.clear();
     this.deletedAt = LocalDateTime.now();
   }
 }

--- a/src/main/java/io/oduck/api/domain/originalAuthor/repository/OriginalAuthorRepository.java
+++ b/src/main/java/io/oduck/api/domain/originalAuthor/repository/OriginalAuthorRepository.java
@@ -7,11 +7,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface OriginalAuthorRepository extends JpaRepository<OriginalAuthor, Long> {
+public interface OriginalAuthorRepository extends JpaRepository<OriginalAuthor, Long>, OriginalAuthorRepositoryCustom {
 
-  boolean existsByName(String name);
-
-  @Query("select distinct oa from OriginalAuthor oa join fetch oa.animeOriginalAuthors where oa.id = :id")
+  @Query("select distinct oa from OriginalAuthor oa left join fetch oa.animeOriginalAuthors where oa.id = :id and  oa.deletedAt = null")
   Optional<OriginalAuthor> findByIdAndDeletedAtIsNull(@Param("id") Long originalAuthorId);
 
   List<OriginalAuthor> findAllByDeletedAtIsNull();

--- a/src/main/java/io/oduck/api/domain/originalAuthor/repository/OriginalAuthorRepository.java
+++ b/src/main/java/io/oduck/api/domain/originalAuthor/repository/OriginalAuthorRepository.java
@@ -1,16 +1,18 @@
 package io.oduck.api.domain.originalAuthor.repository;
 
-import com.querydsl.core.Fetchable;
 import io.oduck.api.domain.originalAuthor.entity.OriginalAuthor;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface OriginalAuthorRepository extends JpaRepository<OriginalAuthor, Long> {
 
   boolean existsByName(String name);
 
-  Optional<OriginalAuthor> findByIdAndDeletedAtIsNull(Long originalAuthorId);
+  @Query("select distinct oa from OriginalAuthor oa join fetch oa.animeOriginalAuthors where oa.id = :id")
+  Optional<OriginalAuthor> findByIdAndDeletedAtIsNull(@Param("id") Long originalAuthorId);
 
   List<OriginalAuthor> findAllByDeletedAtIsNull();
 }

--- a/src/main/java/io/oduck/api/domain/originalAuthor/repository/OriginalAuthorRepositoryCustom.java
+++ b/src/main/java/io/oduck/api/domain/originalAuthor/repository/OriginalAuthorRepositoryCustom.java
@@ -1,0 +1,5 @@
+package io.oduck.api.domain.originalAuthor.repository;
+
+public interface OriginalAuthorRepositoryCustom {
+    boolean existsByName(String name);
+}

--- a/src/main/java/io/oduck/api/domain/originalAuthor/repository/OriginalAuthorRepositoryCustomImpl.java
+++ b/src/main/java/io/oduck/api/domain/originalAuthor/repository/OriginalAuthorRepositoryCustomImpl.java
@@ -1,0 +1,32 @@
+package io.oduck.api.domain.originalAuthor.repository;
+
+
+import static io.oduck.api.domain.originalAuthor.entity.QOriginalAuthor.originalAuthor;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class OriginalAuthorRepositoryCustomImpl implements OriginalAuthorRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public boolean existsByName(String name) {
+        Integer fetchOne = queryFactory.selectOne()
+            .from(originalAuthor)
+            .where(
+                originalAuthor.name.eq(name),
+                notDeleted()
+            )
+            .fetchFirst();
+        return fetchOne != null;
+    }
+
+    private BooleanExpression notDeleted() {
+        return originalAuthor.deletedAt.isNull();
+    }
+}

--- a/src/main/java/io/oduck/api/domain/series/entity/Series.java
+++ b/src/main/java/io/oduck/api/domain/series/entity/Series.java
@@ -1,12 +1,17 @@
 package io.oduck.api.domain.series.entity;
 
+import io.oduck.api.domain.anime.entity.Anime;
 import io.oduck.api.global.audit.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,14 +27,19 @@ public class Series extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(nullable = false, length = 50, unique = true)
+  @Column(nullable = false, length = 50)
   private String title;
+
+  @OneToMany(mappedBy = "series", cascade = CascadeType.PERSIST, orphanRemoval = true)
+  @Builder.Default
+  private List<Anime> animes = new ArrayList<>();
 
   public void update(String title) {
     this.title = title;
   }
 
   public void delete() {
+    this.animes.clear();
     this.deletedAt = LocalDateTime.now();
   }
 }

--- a/src/main/java/io/oduck/api/domain/series/repository/SeriesRepository.java
+++ b/src/main/java/io/oduck/api/domain/series/repository/SeriesRepository.java
@@ -4,12 +4,16 @@ import io.oduck.api.domain.series.entity.Series;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.security.core.parameters.P;
 
 public interface SeriesRepository extends JpaRepository<Series, Long> {
 
   boolean existsByTitle(String title);
 
-  Optional<Series> findByIdAndDeletedAtIsNull(Long seriesId);
+  @Query("select distinct s from Series s join fetch s.animes where s.id = :id")
+  Optional<Series> findByIdAndDeletedAtIsNull(@Param("id") Long seriesId);
 
   List<Series> findAllByDeletedAtIsNull();
 }

--- a/src/main/java/io/oduck/api/domain/series/repository/SeriesRepository.java
+++ b/src/main/java/io/oduck/api/domain/series/repository/SeriesRepository.java
@@ -8,11 +8,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.security.core.parameters.P;
 
-public interface SeriesRepository extends JpaRepository<Series, Long> {
+public interface SeriesRepository extends JpaRepository<Series, Long>, SeriesRepositoryCustom {
 
-  boolean existsByTitle(String title);
-
-  @Query("select distinct s from Series s join fetch s.animes where s.id = :id")
+  @Query("select distinct s from Series s left join fetch s.animes where s.id = :id and s.deletedAt = null")
   Optional<Series> findByIdAndDeletedAtIsNull(@Param("id") Long seriesId);
 
   List<Series> findAllByDeletedAtIsNull();

--- a/src/main/java/io/oduck/api/domain/series/repository/SeriesRepositoryCustom.java
+++ b/src/main/java/io/oduck/api/domain/series/repository/SeriesRepositoryCustom.java
@@ -1,0 +1,6 @@
+package io.oduck.api.domain.series.repository;
+
+public interface SeriesRepositoryCustom {
+
+    boolean existsByTitle(String title);
+}

--- a/src/main/java/io/oduck/api/domain/series/repository/SeriesRepositoryCustomImpl.java
+++ b/src/main/java/io/oduck/api/domain/series/repository/SeriesRepositoryCustomImpl.java
@@ -1,0 +1,31 @@
+package io.oduck.api.domain.series.repository;
+
+import static io.oduck.api.domain.series.entity.QSeries.series;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SeriesRepositoryCustomImpl implements SeriesRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public boolean existsByTitle(String title) {
+        Integer fetchOne = queryFactory.selectOne()
+            .from(series)
+            .where(
+                series.title.eq(title),
+                notDeleted()
+            )
+            .fetchFirst();
+        return fetchOne != null;
+    }
+
+    private BooleanExpression notDeleted() {
+        return series.deletedAt.isNull();
+    }
+}

--- a/src/main/java/io/oduck/api/domain/studio/entity/Studio.java
+++ b/src/main/java/io/oduck/api/domain/studio/entity/Studio.java
@@ -1,12 +1,17 @@
 package io.oduck.api.domain.studio.entity;
 
+import io.oduck.api.domain.anime.entity.AnimeStudio;
 import io.oduck.api.global.audit.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,14 +27,19 @@ public class Studio extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(nullable = false, length = 50, unique = true)
+  @Column(nullable = false, length = 50)
   private String name;
+
+  @OneToMany(mappedBy = "studio", cascade = CascadeType.PERSIST, orphanRemoval = true)
+  @Builder.Default
+  private List<AnimeStudio> animeStudios = new ArrayList<>();
 
   public void update(String name) {
     this.name = name;
   }
 
   public void delete() {
+    this.animeStudios.clear();
     this.deletedAt = LocalDateTime.now();
   }
 }

--- a/src/main/java/io/oduck/api/domain/studio/repository/StudioRepository.java
+++ b/src/main/java/io/oduck/api/domain/studio/repository/StudioRepository.java
@@ -5,12 +5,15 @@ import io.oduck.api.domain.studio.entity.Studio;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface StudioRepository extends JpaRepository<Studio, Long> {
 
   boolean existsByName(String name);
 
-  Optional<Studio> findByIdAndDeletedAtIsNull(Long studioId);
+  @Query("select distinct s from Studio s join fetch s.animeStudios where s.id = :id")
+  Optional<Studio> findByIdAndDeletedAtIsNull(@Param("id") Long studioId);
 
   List<Studio> findAllByDeletedAtIsNull();
 }

--- a/src/main/java/io/oduck/api/domain/studio/repository/StudioRepository.java
+++ b/src/main/java/io/oduck/api/domain/studio/repository/StudioRepository.java
@@ -1,6 +1,5 @@
 package io.oduck.api.domain.studio.repository;
 
-import com.querydsl.core.Fetchable;
 import io.oduck.api.domain.studio.entity.Studio;
 import java.util.List;
 import java.util.Optional;
@@ -8,11 +7,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface StudioRepository extends JpaRepository<Studio, Long> {
+public interface StudioRepository extends JpaRepository<Studio, Long>, StudioRepositoryCustom {
 
-  boolean existsByName(String name);
-
-  @Query("select distinct s from Studio s join fetch s.animeStudios where s.id = :id")
+  @Query("select distinct s from Studio s left join fetch s.animeStudios where s.id = :id and s.deletedAt = null")
   Optional<Studio> findByIdAndDeletedAtIsNull(@Param("id") Long studioId);
 
   List<Studio> findAllByDeletedAtIsNull();

--- a/src/main/java/io/oduck/api/domain/studio/repository/StudioRepositoryCustom.java
+++ b/src/main/java/io/oduck/api/domain/studio/repository/StudioRepositoryCustom.java
@@ -1,0 +1,6 @@
+package io.oduck.api.domain.studio.repository;
+
+public interface StudioRepositoryCustom {
+
+    boolean existsByName(String name);
+}

--- a/src/main/java/io/oduck/api/domain/studio/repository/StudioRepositoryCustomImpl.java
+++ b/src/main/java/io/oduck/api/domain/studio/repository/StudioRepositoryCustomImpl.java
@@ -1,0 +1,31 @@
+package io.oduck.api.domain.studio.repository;
+
+import static io.oduck.api.domain.studio.entity.QStudio.studio;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class StudioRepositoryCustomImpl implements StudioRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public boolean existsByName(String name) {
+        Integer fetchOne = queryFactory.selectOne()
+            .from(studio)
+            .where(
+                studio.name.eq(name),
+                notDeleted()
+            )
+            .fetchFirst();
+        return fetchOne != null;
+    }
+
+    private BooleanExpression notDeleted() {
+        return studio.deletedAt.isNull();
+    }
+}

--- a/src/main/java/io/oduck/api/domain/voiceActor/entity/VoiceActor.java
+++ b/src/main/java/io/oduck/api/domain/voiceActor/entity/VoiceActor.java
@@ -1,12 +1,17 @@
 package io.oduck.api.domain.voiceActor.entity;
 
+import io.oduck.api.domain.anime.entity.AnimeVoiceActor;
 import io.oduck.api.global.audit.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,14 +27,19 @@ public class VoiceActor extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(nullable = false, length = 50, unique = true)
+  @Column(nullable = false, length = 50)
   private String name;
+
+  @OneToMany(mappedBy = "voiceActor", cascade = CascadeType.PERSIST, orphanRemoval = true)
+  @Builder.Default
+  private List<AnimeVoiceActor> animeVoiceActors = new ArrayList<>();
 
   public void update(String name) {
     this.name = name;
   }
 
   public void delete() {
+    animeVoiceActors.clear();
     this.deletedAt = LocalDateTime.now();
   }
 }

--- a/src/main/java/io/oduck/api/domain/voiceActor/repository/VoiceActorRepository.java
+++ b/src/main/java/io/oduck/api/domain/voiceActor/repository/VoiceActorRepository.java
@@ -4,6 +4,8 @@ import io.oduck.api.domain.voiceActor.entity.VoiceActor;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface VoiceActorRepository extends JpaRepository<VoiceActor, Long> {
 
@@ -11,5 +13,6 @@ public interface VoiceActorRepository extends JpaRepository<VoiceActor, Long> {
 
   List<VoiceActor> findAllByDeletedAtIsNull();
 
-  Optional<VoiceActor> findByIdAndDeletedAtIsNull(Long voiceActorId);
+  @Query("select distinct va from VoiceActor va join fetch va.animeVoiceActors where va.id = :id")
+  Optional<VoiceActor> findByIdAndDeletedAtIsNull(@Param("id") Long voiceActorId);
 }

--- a/src/main/java/io/oduck/api/domain/voiceActor/repository/VoiceActorRepository.java
+++ b/src/main/java/io/oduck/api/domain/voiceActor/repository/VoiceActorRepository.java
@@ -7,12 +7,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface VoiceActorRepository extends JpaRepository<VoiceActor, Long> {
-
-  boolean existsByName(String name);
+public interface VoiceActorRepository extends JpaRepository<VoiceActor, Long>, VoiceActorRepositoryCustom {
 
   List<VoiceActor> findAllByDeletedAtIsNull();
 
-  @Query("select distinct va from VoiceActor va join fetch va.animeVoiceActors where va.id = :id")
+  @Query("select distinct va from VoiceActor va left join fetch va.animeVoiceActors where va.id = :id and va.deletedAt = null")
   Optional<VoiceActor> findByIdAndDeletedAtIsNull(@Param("id") Long voiceActorId);
 }

--- a/src/main/java/io/oduck/api/domain/voiceActor/repository/VoiceActorRepositoryCustom.java
+++ b/src/main/java/io/oduck/api/domain/voiceActor/repository/VoiceActorRepositoryCustom.java
@@ -1,0 +1,6 @@
+package io.oduck.api.domain.voiceActor.repository;
+
+public interface VoiceActorRepositoryCustom {
+
+    boolean existsByName(String name);
+}

--- a/src/main/java/io/oduck/api/domain/voiceActor/repository/VoiceActorRepositoryCustomImpl.java
+++ b/src/main/java/io/oduck/api/domain/voiceActor/repository/VoiceActorRepositoryCustomImpl.java
@@ -1,0 +1,31 @@
+package io.oduck.api.domain.voiceActor.repository;
+
+import static io.oduck.api.domain.voiceActor.entity.QVoiceActor.voiceActor;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class VoiceActorRepositoryCustomImpl implements VoiceActorRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public boolean existsByName(String name) {
+        Integer fetchOne = queryFactory.selectOne()
+            .from(voiceActor)
+            .where(
+                voiceActor.name.eq(name),
+                notDeleted()
+            )
+            .fetchFirst();
+        return fetchOne != null;
+    }
+
+    private BooleanExpression notDeleted() {
+        return voiceActor.deletedAt.isNull();
+    }
+}


### PR DESCRIPTION
## 📝 개요
1. 장르, 성우, 원작자, 제작사, 시리즈 삭제 수정 
2. dto의 validator 제약조건, message 수정

## 🚀 변경사항
- 장르, 성우, 원작자, 제작사, 시리즈 유니크 제약조건 제거
- 삭제했을 때 애니와 연관 관계 제거
- 삭제된 장르, 성우, 원작자, 제작사, 시리즈와 동일한 이름이나 제목으로 등록하려고 할 때 등록 되도록 변경

## 🔗 관련 이슈
#102 